### PR TITLE
fix(docs): remove broken external nav links (app, github)

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -20,8 +20,6 @@ export default defineConfig({
       github: 'https://github.com/levino/todo-app',
       navigation: {
         docs: { label: 'Dokumentation', href: '/docs' },
-        app: { label: 'Zur App', href: 'https://todos.levinkeller.de', external: true },
-        github: { label: 'GitHub', href: 'https://github.com/levino/todo-app', external: true },
       },
       scripts: [
         'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js',


### PR DESCRIPTION
Shipyard has a bug where external links get the locale prefix prepended (e.g., /dehttps://...), making them unusable. These links are still available on the landing page.