### PR TITLE
feat(mcp): add extensive debug logging via DEBUG_MCP env var

### DIFF
--- a/packages/mcp/src/oauth/jwt.ts
+++ b/packages/mcp/src/oauth/jwt.ts
@@ -9,6 +9,18 @@ import * as jose from 'jose'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 
+// Debug logging - enable via DEBUG_MCP=true
+const DEBUG = process.env.DEBUG_MCP === 'true'
+
+function debugLog(category: string, message: string, data?: unknown) {
+  if (!DEBUG) return
+  const timestamp = new Date().toISOString()
+  console.log(`[${timestamp}] [DEBUG:${category}] ${message}`)
+  if (data !== undefined) {
+    console.log(JSON.stringify(data, null, 2))
+  }
+}
+
 const ALGORITHM = 'RS256'
 const KEY_ID = 'oauth-key-1'
 
@@ -168,12 +180,33 @@ export async function verifyAccessToken(
     throw new Error('Keys not initialized. Call initKeys first.')
   }
 
+  debugLog('JWT', 'Verifying token', {
+    tokenLength: token.length,
+    expectedIssuer: issuer,
+    expectedAudience: audience,
+  })
+
+  // Decode header without verification to see what we're dealing with
+  try {
+    const parts = token.split('.')
+    if (parts.length === 3) {
+      const headerJson = Buffer.from(parts[0], 'base64url').toString()
+      const payloadJson = Buffer.from(parts[1], 'base64url').toString()
+      debugLog('JWT', 'Token header (unverified)', JSON.parse(headerJson))
+      debugLog('JWT', 'Token payload (unverified)', JSON.parse(payloadJson))
+    }
+  } catch (e) {
+    debugLog('JWT', 'Failed to decode token parts', { error: String(e) })
+  }
+
   try {
     const { payload } = await jose.jwtVerify(token, publicKey, {
       issuer,
       audience,
       algorithms: [ALGORITHM],
     })
+
+    debugLog('JWT', 'Token verified successfully', { payload })
 
     return {
       iss: payload.iss as string,
@@ -184,7 +217,12 @@ export async function verifyAccessToken(
       client_id: payload.client_id as string,
       scope: payload.scope as string | undefined,
     }
-  } catch {
+  } catch (error) {
+    debugLog('JWT', 'Token verification FAILED', {
+      error: String(error),
+      errorName: error instanceof Error ? error.name : 'unknown',
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    })
     return null
   }
 }


### PR DESCRIPTION
Enable with DEBUG_MCP=true to see:
- All incoming requests (headers, body, query)
- All outgoing responses
- OAuth authentication flow details
- JWT token verification (with decoded payload)
- User impersonation steps