### PR TITLE
Add phase switcher so kids can toggle morning/afternoon/evening

### DIFF
--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -30,11 +30,23 @@ export interface Group {
   timezone: string
 }
 
+export const PHASES = ['morning', 'afternoon', 'evening'] as const
+export type Phase = (typeof PHASES)[number]
+
 export const phaseLabels: Record<string, string> = {
   morning: 'Morgens',
   afternoon: 'Nachmittags',
   evening: 'Abends',
 }
+
+export const phaseIcons: Record<Phase, string> = {
+  morning: '🌅',
+  afternoon: '☀️',
+  evening: '🌙',
+}
+
+export const isValidPhase = (value: string | null | undefined): value is Phase =>
+  value === 'morning' || value === 'afternoon' || value === 'evening'
 
 export const getLocalDateString = (timezone: string, now?: Date): string => {
   const tz = timezone || 'Europe/Berlin'

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -9,7 +9,10 @@ import {
   getCurrentPhase,
   sortTasks,
   phaseLabels,
+  phaseIcons,
   getLocalDateString,
+  isValidPhase,
+  PHASES,
 } from '@/lib/tasks'
 
 interface PointTransaction {
@@ -28,6 +31,8 @@ if (!user || !groupId) {
 
 const selectedChildId = Astro.url.searchParams.get('child')
 const showFuture = Astro.url.searchParams.get('showFuture') === 'true'
+const phaseParam = Astro.url.searchParams.get('phase')
+const phaseOverride = isValidPhase(phaseParam) ? phaseParam : null
 
 const actionResult = Astro.getActionResult(actions.completeTask)
 const error = actionResult?.error?.message || ''
@@ -50,7 +55,7 @@ try {
   groupMorningEnd = group.morningEnd || '09:00'
   groupEveningStart = group.eveningStart || '18:00'
   groupTimezone = group.timezone || 'Europe/Berlin'
-  currentPhase = getCurrentPhase(groupMorningEnd, groupEveningStart, groupTimezone)
+  currentPhase = phaseOverride ?? getCurrentPhase(groupMorningEnd, groupEveningStart, groupTimezone)
 
   const childrenResult = await pb.collection('children').getList<Child>(1, 100, {
     filter: `group = "${groupId}"`,
@@ -108,6 +113,13 @@ try {
 const todayStr = getLocalDateString(groupTimezone)
 const showSwitcher = selectedChild && children.length > 1
 const displayChildren = selectedChild ? [selectedChild] : children
+
+const buildPhaseHref = (phase: string) => {
+  const params = new URLSearchParams()
+  if (selectedChildId) params.set('child', selectedChildId)
+  params.set('phase', phase)
+  return `/group/${groupId}/tasks?${params.toString()}`
+}
 ---
 
 <Layout title={selectedChild ? `${selectedChild.name} - Aufgaben` : `${groupName} - Aufgaben`}>
@@ -150,16 +162,39 @@ const displayChildren = selectedChild ? [selectedChild] : children
         </header>
       )}
 
-      <div class="flex items-center gap-2 mb-8">
-        <div transition:name="phase-indicator" data-testid="phase-indicator" class="badge badge-lg badge-outline">
-          {phaseLabels[currentPhase]}
-        </div>
-        {selectedChild && pointsBalanceByChild[selectedChild.id] > 0 && (
+      <nav
+        data-testid="phase-switcher"
+        transition:name="phase-indicator"
+        class="flex gap-2 mb-6"
+      >
+        {PHASES.map((phase) => (
+          <a
+            href={buildPhaseHref(phase)}
+            data-testid={`phase-button-${phase}`}
+            data-active={phase === currentPhase ? 'true' : 'false'}
+            aria-current={phase === currentPhase ? 'page' : undefined}
+            class:list={[
+              'flex-1 flex flex-col items-center justify-center gap-1 px-2 py-3 rounded-2xl min-h-[88px] transition-all duration-150 active:scale-95 no-underline',
+              phase === currentPhase
+                ? 'bg-primary text-primary-content font-bold shadow-lg ring-2 ring-primary'
+                : 'bg-base-200 text-base-content hover:bg-base-300',
+            ]}
+          >
+            <span class="text-4xl md:text-5xl leading-none" aria-hidden="true">{phaseIcons[phase]}</span>
+            <span class="text-base md:text-lg">{phaseLabels[phase]}</span>
+          </a>
+        ))}
+      </nav>
+
+      <div data-testid="phase-indicator" class="sr-only">{phaseLabels[currentPhase]}</div>
+
+      {selectedChild && pointsBalanceByChild[selectedChild.id] > 0 && (
+        <div class="mb-8">
           <div data-testid="points-balance" class="badge badge-lg badge-warning gap-1">
             {pointsBalanceByChild[selectedChild.id]} Punkte
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       {children.length === 0 && !selectedChild && (
         <div class="text-center py-16">
@@ -395,40 +430,42 @@ const displayChildren = selectedChild ? [selectedChild] : children
     })
   </script>
 
-  <script define:vars={{ currentPhase, groupMorningEnd, groupEveningStart, groupTimezone }}>
-    const parseTime = (timeStr) => {
-      const [h, m] = timeStr.split(':').map(Number)
-      return h * 60 + m
-    }
-
-    const morningEndMinutes = parseTime(groupMorningEnd)
-    const eveningStartMinutes = parseTime(groupEveningStart)
-
-    const getLocalMinutes = () => {
-      const now = new Date()
-      const formatter = new Intl.DateTimeFormat('en-US', {
-        timeZone: groupTimezone || 'Europe/Berlin',
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: false,
-      })
-      const parts = formatter.formatToParts(now)
-      const hour = Number(parts.find(p => p.type === 'hour')?.value || 0)
-      const minute = Number(parts.find(p => p.type === 'minute')?.value || 0)
-      return hour * 60 + minute
-    }
-
-    const getPhase = (minutes) => {
-      if (minutes < morningEndMinutes) return 'morning'
-      if (minutes < eveningStartMinutes) return 'afternoon'
-      return 'evening'
-    }
-
-    setInterval(() => {
-      if (getPhase(getLocalMinutes()) !== currentPhase) {
-        window.location.reload()
+  <script define:vars={{ currentPhase, groupMorningEnd, groupEveningStart, groupTimezone, phaseOverride }}>
+    if (!phaseOverride) {
+      const parseTime = (timeStr) => {
+        const [h, m] = timeStr.split(':').map(Number)
+        return h * 60 + m
       }
-    }, 60000)
+
+      const morningEndMinutes = parseTime(groupMorningEnd)
+      const eveningStartMinutes = parseTime(groupEveningStart)
+
+      const getLocalMinutes = () => {
+        const now = new Date()
+        const formatter = new Intl.DateTimeFormat('en-US', {
+          timeZone: groupTimezone || 'Europe/Berlin',
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: false,
+        })
+        const parts = formatter.formatToParts(now)
+        const hour = Number(parts.find(p => p.type === 'hour')?.value || 0)
+        const minute = Number(parts.find(p => p.type === 'minute')?.value || 0)
+        return hour * 60 + minute
+      }
+
+      const getPhase = (minutes) => {
+        if (minutes < morningEndMinutes) return 'morning'
+        if (minutes < eveningStartMinutes) return 'afternoon'
+        return 'evening'
+      }
+
+      setInterval(() => {
+        if (getPhase(getLocalMinutes()) !== currentPhase) {
+          window.location.reload()
+        }
+      }, 60000)
+    }
   </script>
 
   <script is:inline>

--- a/packages/frontend/tests/pages/group/phase-switcher.integration.test.ts
+++ b/packages/frontend/tests/pages/group/phase-switcher.integration.test.ts
@@ -1,0 +1,167 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import PocketBase from 'pocketbase'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { resetPocketBase } from '@/lib/pocketbase'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+describe('Phase Switcher', () => {
+  let adminPb: PocketBase
+  let userPb: PocketBase
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    resetPocketBase()
+
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb.collection('_superusers').authWithPassword('admin@test.local', 'testtest123')
+
+    const email = `test-${Date.now()}@example.com`
+    const user = await adminPb.collection('users').create({
+      email,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+    })
+
+    userPb = new PocketBase(POCKETBASE_URL)
+    await userPb.collection('users').authWithPassword(email, 'testtest123')
+
+    const group = await adminPb.collection('groups').create({
+      name: 'Test Family',
+      morningEnd: '09:00',
+      eveningStart: '18:00',
+      timezone: 'Europe/Berlin',
+    })
+    groupId = group.id
+
+    await adminPb.collection('user_groups').create({
+      user: user.id,
+      group: groupId,
+    })
+
+    const child = await adminPb.collection('children').create({
+      name: 'Kind',
+      color: '#FF6B6B',
+      group: groupId,
+    })
+    childId = child.id
+
+    await adminPb.collection('tasks').create({
+      title: 'Morgenaufgabe',
+      child: childId,
+      priority: 1,
+      completed: false,
+      timeOfDay: 'morning',
+    })
+    await adminPb.collection('tasks').create({
+      title: 'Nachmittagsaufgabe',
+      child: childId,
+      priority: 1,
+      completed: false,
+      timeOfDay: 'afternoon',
+    })
+    await adminPb.collection('tasks').create({
+      title: 'Abendaufgabe',
+      child: childId,
+      priority: 1,
+      completed: false,
+      timeOfDay: 'evening',
+    })
+
+    container = await AstroContainer.create()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const renderPage = (query = '') =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { pb: userPb, user: userPb.authStore.record },
+      request: new Request(`http://localhost/group/${groupId}/tasks?child=${childId}${query ? `&${query}` : ''}`),
+    })
+
+  it('renders three phase buttons on the tasks page', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z')) // 14:00 Berlin → afternoon
+    const html = await renderPage()
+    expect(html).toContain('data-testid="phase-button-morning"')
+    expect(html).toContain('data-testid="phase-button-afternoon"')
+    expect(html).toContain('data-testid="phase-button-evening"')
+  })
+
+  it('marks the calculated phase as active when no query param is set', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z')) // 14:00 Berlin → afternoon
+    const html = await renderPage()
+    expect(html).toMatch(/data-testid="phase-button-afternoon"[^>]*data-active="true"/)
+    expect(html).not.toMatch(/data-testid="phase-button-morning"[^>]*data-active="true"/)
+    expect(html).not.toMatch(/data-testid="phase-button-evening"[^>]*data-active="true"/)
+  })
+
+  it('overrides the phase with ?phase=morning even when real time is afternoon', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z')) // 14:00 Berlin → afternoon
+    const html = await renderPage('phase=morning')
+    expect(html).toContain('Morgenaufgabe')
+    expect(html).not.toContain('Nachmittagsaufgabe')
+    expect(html).not.toContain('Abendaufgabe')
+    expect(html).toMatch(/data-testid="phase-button-morning"[^>]*data-active="true"/)
+  })
+
+  it('overrides the phase with ?phase=evening even when real time is morning', async () => {
+    vi.setSystemTime(new Date('2026-03-10T06:00:00Z')) // 07:00 Berlin → morning
+    const html = await renderPage('phase=evening')
+    expect(html).toContain('Abendaufgabe')
+    expect(html).not.toContain('Morgenaufgabe')
+    expect(html).not.toContain('Nachmittagsaufgabe')
+    expect(html).toMatch(/data-testid="phase-button-evening"[^>]*data-active="true"/)
+  })
+
+  it('overrides the phase with ?phase=afternoon even when real time is evening', async () => {
+    vi.setSystemTime(new Date('2026-03-10T19:00:00Z')) // 20:00 Berlin → evening
+    const html = await renderPage('phase=afternoon')
+    expect(html).toContain('Nachmittagsaufgabe')
+    expect(html).not.toContain('Morgenaufgabe')
+    expect(html).not.toContain('Abendaufgabe')
+    expect(html).toMatch(/data-testid="phase-button-afternoon"[^>]*data-active="true"/)
+  })
+
+  it('ignores an invalid phase query and falls back to the calculated phase', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z')) // 14:00 Berlin → afternoon
+    const html = await renderPage('phase=bogus')
+    expect(html).toContain('Nachmittagsaufgabe')
+    expect(html).not.toContain('Morgenaufgabe')
+    expect(html).not.toContain('Abendaufgabe')
+    expect(html).toMatch(/data-testid="phase-button-afternoon"[^>]*data-active="true"/)
+  })
+
+  it('phase button links preserve the child query param', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z'))
+    const html = await renderPage()
+    for (const phase of ['morning', 'afternoon', 'evening'] as const) {
+      const match = new RegExp(
+        `data-testid="phase-button-${phase}"[^>]*href="[^"]*child=${childId}[^"]*phase=${phase}"`,
+      )
+      const reverseMatch = new RegExp(
+        `href="[^"]*child=${childId}[^"]*phase=${phase}"[^>]*data-testid="phase-button-${phase}"`,
+      )
+      expect(html).toMatch(new RegExp(`${match.source}|${reverseMatch.source}`))
+    }
+  })
+
+  it('phase switcher is rendered on the group overview (no child selected)', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z'))
+    const html = await container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { pb: userPb, user: userPb.authStore.record },
+      request: new Request(`http://localhost/group/${groupId}/tasks`),
+    })
+    expect(html).toContain('data-testid="phase-button-morning"')
+    expect(html).toContain('data-testid="phase-button-afternoon"')
+    expect(html).toContain('data-testid="phase-button-evening"')
+    expect(html).toContain(`/group/${groupId}/tasks?phase=morning`)
+  })
+})


### PR DESCRIPTION
Replaces the single phase indicator badge with three large, tablet-friendly
buttons that let kids switch between morning, afternoon, and evening without
waiting for the server clock. The server reads the selected phase from a
?phase= query parameter and falls back to the calculated phase when the
parameter is missing or invalid. The auto-reload on phase boundary is skipped
while an override is active so the override is not clobbered.

https://claude.ai/code/session_018EYfsjiqECKfRUtXegCi6P