### PR TITLE
Tasks page: one view-table fetch + prefetch phase buttons

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,6 +130,51 @@ This ensures each test starts with a clean database.
 - **Not required at this stage** - integration tests cover functionality
 - Only add later for critical user flows if needed
 
+## View-Tables statt Multi-Fetch
+
+**Jede Page fetcht aus genau einer, für sie optimierten PocketBase-View-Collection.**
+
+Eine View-Collection ist ein SQL SELECT, das in der Datenbank läuft (SQLite im
+PocketBase-Prozess). Filter, JOINs und Aggregate (`SUM`, `COUNT`) werden dort
+ausgeführt — das ist Größenordnungen schneller als mehrere HTTP-Fetches vom
+Client. Die Page ruft dann genau eine Collection ab, filtert minimal und gruppiert
+client-seitig.
+
+### Regeln
+
+1. **Eine Page → eine View-Collection.** Kein `for`-Loop mit sequenziellen
+   `await pb.collection(...).getList(...)`. Wenn die Page Daten aus mehreren
+   Tabellen braucht, löst die View das per JOIN.
+2. **Keine JSON-Spalten in der Datenbank.** Alle View-Spalten müssen echte SQL-Typen
+   haben (text/number/bool/date/relation). Wenn PocketBase einen Ausdruck nicht
+   inferred, hilft `CAST(... AS REAL/INTEGER/TEXT)`. Komplexe `COALESCE`s
+   vermeiden — PocketBase fällt sonst auf `json` zurück.
+3. **Aggregate im View, nicht im Client.** `SUM(points)` als Subquery im View,
+   nicht `getFullList` plus `reduce` im Frontend.
+4. **Indexes sind Pflicht** für alle Spalten, auf denen die View filtert, joint
+   oder sortiert (inkl. der Subqueries innerhalb der View). PocketBase indexiert
+   nicht automatisch, auch nicht Relation-Felder. Index-Pflege läuft über
+   `pb.collections.update(name, { indexes: ['CREATE INDEX ...'] })`.
+5. **Denormalisierung ist erlaubt, aber nicht Pflicht.** Wenn eine View mit JOINs
+   und Subqueries sauber bleibt, reicht das. Ein denormalisiertes Feld (gepflegt
+   via MCP-Tool oder pb_hooks) ist ok, wenn es die View-Definition deutlich
+   vereinfacht.
+
+### Namenskonvention
+
+- View-Collection heißt nach der Page: `tasks_page_view`, `stats_page_view`, …
+- Spalten-Präfixe spiegeln die Basistabelle: `child_name`, `task_title`,
+  `group_id` — so ist im Client klar, woher das Feld kommt.
+
+### Beispiel
+
+Die Tasks-Page (`src/pages/group/[groupId]/tasks/index.astro`) nutzt
+`tasks_page_view`: ein `LEFT JOIN` zwischen `children` und `tasks`, Phantom-Zeile
+für Kinder ohne Tasks, `CAST(SUM(points) AS REAL)` als Subquery auf
+`point_transactions`. Die Page macht einen Fetch und splittet mit
+`splitViewRowsByChild` (`src/lib/tasks.ts`) client-seitig in active / completed /
+future.
+
 ## PocketBase Database Schema Changes
 
 **Never write migration SQL by hand!**

--- a/packages/api/pocketbase/pb_migrations/1776792135_created_tasks_page_view.js
+++ b/packages/api/pocketbase/pb_migrations/1776792135_created_tasks_page_view.js
@@ -1,0 +1,226 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 0,
+        "min": 0,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "cascadeDelete": false,
+        "collectionId": "pbc_3789154723",
+        "hidden": false,
+        "id": "relation3714236955",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "child_id",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "_clone_9Wxa",
+        "max": 0,
+        "min": 0,
+        "name": "child_name",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "_clone_YK3Y",
+        "max": 0,
+        "min": 0,
+        "name": "child_color",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "cascadeDelete": false,
+        "collectionId": "pbc_3346940990",
+        "hidden": false,
+        "id": "_clone_558m",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "group_id",
+        "presentable": false,
+        "required": true,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "hidden": false,
+        "id": "number3701867583",
+        "max": null,
+        "min": null,
+        "name": "child_points_balance",
+        "onlyInt": false,
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "number"
+      },
+      {
+        "cascadeDelete": false,
+        "collectionId": "pbc_2254914799",
+        "hidden": false,
+        "id": "relation2377515398",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "task_id",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "_clone_p6YH",
+        "max": 0,
+        "min": 0,
+        "name": "task_title",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_vG2A",
+        "max": null,
+        "min": null,
+        "name": "task_priority",
+        "onlyInt": false,
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "number"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_Nzq3",
+        "maxSelect": 1,
+        "name": "task_time_of_day",
+        "presentable": false,
+        "required": true,
+        "system": false,
+        "type": "select",
+        "values": [
+          "morning",
+          "afternoon",
+          "evening"
+        ]
+      },
+      {
+        "hidden": false,
+        "id": "_clone_HhGh",
+        "max": "",
+        "min": "",
+        "name": "task_due_date",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "date"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_ncT4",
+        "name": "task_completed",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "bool"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_gwOY",
+        "max": "",
+        "min": "",
+        "name": "task_completed_at",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "date"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_byVQ",
+        "max": "",
+        "min": "",
+        "name": "task_last_completed_at",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "date"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "_clone_tjtz",
+        "max": 0,
+        "min": 0,
+        "name": "task_recurrence_type",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "_clone_R3qB",
+        "max": null,
+        "min": 0,
+        "name": "task_points",
+        "onlyInt": true,
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "number"
+      }
+    ],
+    "id": "pbc_4142202888",
+    "indexes": [],
+    "listRule": "",
+    "name": "tasks_page_view",
+    "system": false,
+    "type": "view",
+    "updateRule": null,
+    "viewQuery": "SELECT\n  (c.id || '-' || COALESCE(t.id, 'none')) AS id,\n  c.id AS child_id,\n  c.name AS child_name,\n  c.color AS child_color,\n  c.\"group\" AS group_id,\n  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child = c.id) AS REAL) AS child_points_balance,\n  t.id AS task_id,\n  t.title AS task_title,\n  t.priority AS task_priority,\n  t.timeOfDay AS task_time_of_day,\n  t.dueDate AS task_due_date,\n  t.completed AS task_completed,\n  t.completedAt AS task_completed_at,\n  t.lastCompletedAt AS task_last_completed_at,\n  t.recurrenceType AS task_recurrence_type,\n  t.points AS task_points\nFROM children c\nLEFT JOIN tasks t ON t.child = c.id",
+    "viewRule": ""
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4142202888");
+
+  return app.delete(collection);
+})

--- a/packages/api/pocketbase/pb_migrations/1776792220_updated_children.js
+++ b/packages/api/pocketbase/pb_migrations/1776792220_updated_children.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3789154723")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX `idx_children_group_name` ON `children` (`group`, `name`)"
+    ]
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3789154723")
+
+  // update collection data
+  unmarshal({
+    "indexes": []
+  }, collection)
+
+  return app.save(collection)
+})

--- a/packages/api/pocketbase/pb_migrations/1776792220_updated_point_transactions.js
+++ b/packages/api/pocketbase/pb_migrations/1776792220_updated_point_transactions.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1980370882")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX `idx_point_transactions_child` ON `point_transactions` (`child`)"
+    ]
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1980370882")
+
+  // update collection data
+  unmarshal({
+    "indexes": []
+  }, collection)
+
+  return app.save(collection)
+})

--- a/packages/api/pocketbase/pb_migrations/1776792220_updated_tasks.js
+++ b/packages/api/pocketbase/pb_migrations/1776792220_updated_tasks.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2254914799")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX `idx_tasks_child` ON `tasks` (`child`)"
+    ]
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2254914799")
+
+  // update collection data
+  unmarshal({
+    "indexes": []
+  }, collection)
+
+  return app.save(collection)
+})

--- a/packages/frontend/astro.config.mjs
+++ b/packages/frontend/astro.config.mjs
@@ -8,6 +8,9 @@ import appCss from './src/styles/app.css?url'
 export default defineConfig({
   site: 'https://your-site.example.com',
   output: 'server',
+  prefetch: {
+    defaultStrategy: 'tap',
+  },
   adapter: node({
     mode: 'standalone',
   }),

--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -33,6 +33,117 @@ export interface Group {
 export const PHASES = ['morning', 'afternoon', 'evening'] as const
 export type Phase = (typeof PHASES)[number]
 
+export interface TasksPageViewRow {
+  id: string
+  child_id: string
+  child_name: string
+  child_color: string
+  group_id: string
+  child_points_balance: number | null
+  task_id: string
+  task_title: string
+  task_priority: number | null
+  task_time_of_day: string
+  task_due_date: string
+  task_completed: boolean
+  task_completed_at: string
+  task_last_completed_at: string
+  task_recurrence_type: string
+  task_points: number
+}
+
+export const viewRowToTask = (row: TasksPageViewRow): Task => ({
+  id: row.task_id,
+  title: row.task_title,
+  child: row.child_id,
+  priority: row.task_priority,
+  completed: row.task_completed,
+  completedAt: row.task_completed_at || null,
+  dueDate: row.task_due_date || null,
+  recurrenceType: row.task_recurrence_type || null,
+  recurrenceInterval: null,
+  recurrenceDays: null,
+  timeOfDay: row.task_time_of_day,
+  lastCompletedAt: row.task_last_completed_at || null,
+  completedBy: null,
+  points: row.task_points,
+})
+
+export interface ChildTasksSplit {
+  child: Child
+  pointsBalance: number
+  active: Task[]
+  recentlyCompleted: Task[]
+  future: Task[]
+}
+
+export const splitViewRowsByChild = (
+  rows: TasksPageViewRow[],
+  params: {
+    phase: Phase
+    todayDateStr: string
+    timezone: string
+    showFuture: boolean
+  },
+): ChildTasksSplit[] => {
+  const byChildId = new Map<string, ChildTasksSplit>()
+
+  for (const row of rows) {
+    let bucket = byChildId.get(row.child_id)
+    if (!bucket) {
+      bucket = {
+        child: {
+          id: row.child_id,
+          name: row.child_name,
+          color: row.child_color,
+          group: row.group_id,
+        },
+        pointsBalance: row.child_points_balance ?? 0,
+        active: [],
+        recentlyCompleted: [],
+        future: [],
+      }
+      byChildId.set(row.child_id, bucket)
+    }
+
+    if (!row.task_id) continue
+
+    const task = viewRowToTask(row)
+    const dueDateStr = row.task_due_date ? row.task_due_date.slice(0, 10) : ''
+    const completedAtDateStr = row.task_completed_at ? row.task_completed_at.slice(0, 10) : ''
+    const lastCompletedAtDateStr = row.task_last_completed_at ? row.task_last_completed_at.slice(0, 10) : ''
+
+    const isActive =
+      !row.task_completed &&
+      row.task_time_of_day === params.phase &&
+      (!dueDateStr || dueDateStr <= params.todayDateStr)
+
+    const isRecentlyCompleted =
+      (row.task_completed && completedAtDateStr === params.todayDateStr) ||
+      (!row.task_completed &&
+        !!row.task_recurrence_type &&
+        lastCompletedAtDateStr === params.todayDateStr)
+
+    const isFuture =
+      !row.task_completed && !!dueDateStr && dueDateStr > params.todayDateStr
+
+    if (isActive) bucket.active.push(task)
+    if (isRecentlyCompleted) bucket.recentlyCompleted.push(task)
+    if (params.showFuture && isFuture) bucket.future.push(task)
+  }
+
+  for (const bucket of byChildId.values()) {
+    bucket.active = sortTasks(bucket.active, params.timezone)
+    bucket.future.sort((a, b) => {
+      if (!a.dueDate) return 1
+      if (!b.dueDate) return -1
+      return a.dueDate.localeCompare(b.dueDate)
+    })
+  }
+
+  return Array.from(byChildId.values()).sort((a, b) => a.child.name.localeCompare(b.child.name))
+}
+
 export const phaseLabels: Record<string, string> = {
   morning: 'Morgens',
   afternoon: 'Nachmittags',

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -6,21 +6,17 @@ import {
   type Task,
   type Child,
   type Group,
+  type TasksPageViewRow,
+  type ChildTasksSplit,
   getCurrentPhase,
-  sortTasks,
   phaseLabels,
   phaseIcons,
   getLocalDateString,
   isValidPhase,
+  splitViewRowsByChild,
   PHASES,
+  type Phase,
 } from '@/lib/tasks'
-
-interface PointTransaction {
-  id: string
-  child: string
-  points: number
-  type: string
-}
 
 const { groupId } = Astro.params
 const { pb, user } = Astro.locals
@@ -37,82 +33,62 @@ const phaseOverride = isValidPhase(phaseParam) ? phaseParam : null
 const actionResult = Astro.getActionResult(actions.completeTask)
 const error = actionResult?.error?.message || ''
 
-let children: Child[] = []
-let tasksByChild: Record<string, Task[]> = {}
-let selectedChild: Child | null = null
-let recentlyCompletedByChild: Record<string, Task[]> = {}
-let futureTasksByChild: Record<string, Task[]> = {}
-let currentPhase = 'afternoon'
+let childSplits: ChildTasksSplit[] = []
+let currentPhase: Phase = 'afternoon'
 let groupMorningEnd = '09:00'
 let groupEveningStart = '18:00'
 let groupTimezone = 'Europe/Berlin'
 let groupName = ''
-let pointsBalanceByChild: Record<string, number> = {}
 
 try {
-  const group = await pb.collection('groups').getOne<Group>(groupId)
+  const [group, viewRows] = await Promise.all([
+    pb.collection('groups').getOne<Group>(groupId),
+    pb.collection('tasks_page_view').getFullList<TasksPageViewRow>({
+      filter: `group_id = "${groupId}"`,
+    }),
+  ])
+
   groupName = group.name
   groupMorningEnd = group.morningEnd || '09:00'
   groupEveningStart = group.eveningStart || '18:00'
   groupTimezone = group.timezone || 'Europe/Berlin'
-  currentPhase = phaseOverride ?? getCurrentPhase(groupMorningEnd, groupEveningStart, groupTimezone)
+  currentPhase = phaseOverride ?? (getCurrentPhase(groupMorningEnd, groupEveningStart, groupTimezone) as Phase)
 
-  const childrenResult = await pb.collection('children').getList<Child>(1, 100, {
-    filter: `group = "${groupId}"`,
-    sort: 'name',
+  const todayDateStr = getLocalDateString(groupTimezone)
+
+  childSplits = splitViewRowsByChild(viewRows, {
+    phase: currentPhase,
+    todayDateStr,
+    timezone: groupTimezone,
+    showFuture,
   })
-  children = childrenResult.items
-
-  if (selectedChildId) {
-    selectedChild = children.find((c) => c.id === selectedChildId) || null
-  }
-
-  const now = new Date()
-  const todayDateStr = getLocalDateString(groupTimezone, now)
-  const todayEnd = todayDateStr + ' 23:59:59.999Z'
-  const todayStart = todayDateStr + ' 00:00:00.000Z'
-
-  const displayChildren = selectedChild ? [selectedChild] : children
-
-  for (const child of displayChildren) {
-    // tasks
-    const result = await pb.collection('tasks').getList<Task>(1, 100, {
-      filter: `child = "${child.id}" && completed = false && timeOfDay = "${currentPhase}" && (dueDate = "" || dueDate <= "${todayEnd}")`,
-    })
-    tasksByChild[child.id] = sortTasks(result.items, groupTimezone)
-
-    // recently completed
-    const recentResult = await pb.collection('tasks').getList<Task>(1, 100, {
-      filter: `child = "${child.id}" && ((completed = true && completedAt >= "${todayStart}") || (completed = false && lastCompletedAt >= "${todayStart}" && lastCompletedAt != "" && recurrenceType != ""))`,
-    })
-    recentlyCompletedByChild[child.id] = recentResult.items
-
-    // points
-    try {
-      const txResult = await pb.collection('point_transactions').getFullList<PointTransaction>({
-        filter: `child = "${child.id}"`,
-      })
-      pointsBalanceByChild[child.id] = txResult.reduce((sum, t) => sum + t.points, 0)
-    } catch {
-      pointsBalanceByChild[child.id] = 0
-    }
-
-    // future tasks
-    if (showFuture) {
-      const futureResult = await pb.collection('tasks').getList<Task>(1, 100, {
-        filter: `child = "${child.id}" && completed = false && dueDate > "${todayEnd}"`,
-        sort: 'dueDate',
-      })
-      futureTasksByChild[child.id] = futureResult.items
-    }
-  }
 } catch (e) {
   console.error('Page fetch error:', e)
 }
 
+const children: Child[] = childSplits.map((s) => s.child)
+const selectedSplit = selectedChildId
+  ? childSplits.find((s) => s.child.id === selectedChildId) ?? null
+  : null
+const selectedChild: Child | null = selectedSplit?.child ?? null
+
 const todayStr = getLocalDateString(groupTimezone)
 const showSwitcher = selectedChild && children.length > 1
-const displayChildren = selectedChild ? [selectedChild] : children
+const displaySplits = selectedSplit ? [selectedSplit] : childSplits
+const displayChildren: Child[] = displaySplits.map((s) => s.child)
+
+const tasksByChild: Record<string, Task[]> = Object.fromEntries(
+  displaySplits.map((s) => [s.child.id, s.active]),
+)
+const recentlyCompletedByChild: Record<string, Task[]> = Object.fromEntries(
+  displaySplits.map((s) => [s.child.id, s.recentlyCompleted]),
+)
+const futureTasksByChild: Record<string, Task[]> = Object.fromEntries(
+  displaySplits.map((s) => [s.child.id, s.future]),
+)
+const pointsBalanceByChild: Record<string, number> = Object.fromEntries(
+  displaySplits.map((s) => [s.child.id, s.pointsBalance]),
+)
 
 const buildPhaseHref = (phase: string) => {
   const params = new URLSearchParams()
@@ -172,6 +148,7 @@ const buildPhaseHref = (phase: string) => {
             href={buildPhaseHref(phase)}
             data-testid={`phase-button-${phase}`}
             data-active={phase === currentPhase ? 'true' : 'false'}
+            data-astro-prefetch
             aria-current={phase === currentPhase ? 'page' : undefined}
             class:list={[
               'flex-1 flex flex-col items-center justify-center gap-1 px-2 py-3 rounded-2xl min-h-[88px] transition-all duration-150 active:scale-95 no-underline',

--- a/packages/frontend/tests/lib/tasks-page-view.integration.test.ts
+++ b/packages/frontend/tests/lib/tasks-page-view.integration.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import PocketBase from 'pocketbase'
+import { resetPocketBase } from '@/lib/pocketbase'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+interface TasksPageViewRow {
+  id: string
+  child_id: string
+  child_name: string
+  child_color: string
+  group_id: string
+  child_points_balance: number
+  task_id: string
+  task_title: string
+  task_priority: number | null
+  task_time_of_day: string
+  task_due_date: string
+  task_completed: boolean
+  task_completed_at: string
+  task_last_completed_at: string
+  task_recurrence_type: string
+  task_points: number
+}
+
+describe('tasks_page_view collection', () => {
+  let adminPb: PocketBase
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    resetPocketBase()
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb.collection('_superusers').authWithPassword('admin@test.local', 'testtest123')
+
+    const group = await adminPb.collection('groups').create({ name: 'Test Group' })
+    groupId = group.id
+
+    const child = await adminPb.collection('children').create({
+      name: 'Kid',
+      color: '#FF6B6B',
+      group: groupId,
+    })
+    childId = child.id
+  })
+
+  it('returns one row per task of a child, with child and task fields', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Morgenaufgabe',
+      child: childId,
+      priority: 1,
+      completed: false,
+      timeOfDay: 'morning',
+      points: 5,
+    })
+
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `child_id = "${childId}"` })
+
+    const taskRow = rows.find((r) => r.task_title === 'Morgenaufgabe')
+    expect(taskRow).toBeDefined()
+    expect(taskRow!.child_id).toBe(childId)
+    expect(taskRow!.child_name).toBe('Kid')
+    expect(taskRow!.child_color).toBe('#FF6B6B')
+    expect(taskRow!.group_id).toBe(groupId)
+    expect(taskRow!.task_time_of_day).toBe('morning')
+    expect(taskRow!.task_points).toBe(5)
+  })
+
+  it('returns a phantom row for a child with no tasks', async () => {
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `child_id = "${childId}"` })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].child_id).toBe(childId)
+    expect(rows[0].task_id).toBe('')
+    expect(rows[0].task_title).toBe('')
+  })
+
+  it('aggregates child_points_balance as sum of point_transactions', async () => {
+    await adminPb.collection('point_transactions').create({
+      child: childId,
+      points: 10,
+      type: 'earned',
+    })
+    await adminPb.collection('point_transactions').create({
+      child: childId,
+      points: 5,
+      type: 'earned',
+    })
+    await adminPb.collection('point_transactions').create({
+      child: childId,
+      points: -3,
+      type: 'redeemed',
+    })
+
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `child_id = "${childId}"` })
+
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.child_points_balance).toBe(12)
+    }
+  })
+
+  it('returns zero child_points_balance when child has no transactions', async () => {
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `child_id = "${childId}"` })
+
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.child_points_balance).toBe(0)
+    }
+  })
+
+  it('filters rows by group_id', async () => {
+    const otherGroup = await adminPb.collection('groups').create({ name: 'Other' })
+    const otherChild = await adminPb.collection('children').create({
+      name: 'Other Kid',
+      color: '#4DABF7',
+      group: otherGroup.id,
+    })
+    await adminPb.collection('tasks').create({
+      title: 'OtherTask',
+      child: otherChild.id,
+      priority: 1,
+      completed: false,
+      timeOfDay: 'afternoon',
+    })
+
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `group_id = "${groupId}"` })
+
+    for (const row of rows) {
+      expect(row.group_id).toBe(groupId)
+      expect(row.task_title).not.toBe('OtherTask')
+    }
+  })
+
+  it('includes completed tasks (not just active ones)', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'DoneTask',
+      child: childId,
+      priority: 1,
+      completed: true,
+      completedAt: '2026-03-10 10:00:00.000Z',
+      timeOfDay: 'morning',
+    })
+
+    const rows = await adminPb
+      .collection<TasksPageViewRow>('tasks_page_view')
+      .getFullList({ filter: `child_id = "${childId}" && task_title = "DoneTask"` })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].task_completed).toBe(true)
+  })
+})

--- a/packages/frontend/tests/pages/group/phase-switcher.integration.test.ts
+++ b/packages/frontend/tests/pages/group/phase-switcher.integration.test.ts
@@ -94,6 +94,16 @@ describe('Phase Switcher', () => {
     expect(html).toContain('data-testid="phase-button-evening"')
   })
 
+  it('phase buttons opt into Astro prefetch so the target page is ready on click', async () => {
+    vi.setSystemTime(new Date('2026-03-10T13:00:00Z'))
+    const html = await renderPage()
+    for (const phase of ['morning', 'afternoon', 'evening'] as const) {
+      expect(html).toMatch(
+        new RegExp(`data-testid="phase-button-${phase}"[^>]*data-astro-prefetch`),
+      )
+    }
+  })
+
   it('marks the calculated phase as active when no query param is set', async () => {
     vi.setSystemTime(new Date('2026-03-10T13:00:00Z')) // 14:00 Berlin → afternoon
     const html = await renderPage()


### PR DESCRIPTION
## Summary
- Replaces the N×3 sequential PocketBase fetches in `tasks/index.astro` with a single query against a new `tasks_page_view` collection (SQL SELECT with JOIN + `CAST(SUM(points) AS REAL)` subquery). Phantom row per child preserves the "all done" celebration for kids without tasks.
- Adds indexes on `tasks.child`, `children(group, name)` and `point_transactions.child` — nothing was indexed before, so the existing queries (and the new view) were full table scans.
- Enables Astro prefetch (`defaultStrategy: 'tap'`) and marks the three phase buttons with `data-astro-prefetch` so the target page is in the browser cache by the time the kid lifts their finger.
- Documents the architectural rule in `.claude/CLAUDE.md` ("View-Tables statt Multi-Fetch"): one view per page, SQL-typed columns only (no json fallback), indexes mandatory, aggregates inside the view.

## Test plan
- [x] `npm run docker:test` — 222/222 passing (6 new tests for `tasks_page_view`, 1 new test for prefetch attribute, all pre-existing tests still green).
- [ ] Manual: switch between Morgens/Nachmittags/Abends on the tablet — the switch should now feel near-instant because (a) one HTTP round-trip instead of many, (b) aggregates and filters run inside SQLite, (c) the target page is prefetched on `touchstart`.
- [ ] Manual: verify the Dev-Tools Network tab shows exactly one request to `/api/collections/tasks_page_view/records` per page render.

https://claude.ai/code/session_018EYfsjiqECKfRUtXegCi6P