### PR TITLE
Let kids complete/delete tasks any time, add chore category

### DIFF
--- a/packages/api/pocketbase/pb_migrations/1776919349_updated_tasks.js
+++ b/packages/api/pocketbase/pb_migrations/1776919349_updated_tasks.js
@@ -1,0 +1,25 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2254914799")
+
+  // add field
+  collection.fields.addAt(15, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "bool2356106988",
+    "name": "isChore",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2254914799")
+
+  // remove field
+  collection.fields.removeById("bool2356106988")
+
+  return app.save(collection)
+})

--- a/packages/api/pocketbase/pb_migrations/1776919349_updated_tasks_page_view.js
+++ b/packages/api/pocketbase/pb_migrations/1776919349_updated_tasks_page_view.js
@@ -1,0 +1,480 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4142202888")
+
+  // update collection data
+  unmarshal({
+    "viewQuery": "SELECT\n  (c.id || '-' || COALESCE(t.id, 'none')) AS id,\n  c.id AS child_id,\n  c.name AS child_name,\n  c.color AS child_color,\n  c.\"group\" AS group_id,\n  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child = c.id) AS REAL) AS child_points_balance,\n  t.id AS task_id,\n  t.title AS task_title,\n  t.priority AS task_priority,\n  t.timeOfDay AS task_time_of_day,\n  t.dueDate AS task_due_date,\n  t.completed AS task_completed,\n  t.completedAt AS task_completed_at,\n  t.lastCompletedAt AS task_last_completed_at,\n  t.recurrenceType AS task_recurrence_type,\n  t.points AS task_points,\n  COALESCE(t.isChore, 0) AS task_is_chore\nFROM children c\nLEFT JOIN tasks t ON t.child = c.id"
+  }, collection)
+
+  // remove field
+  collection.fields.removeById("_clone_WzuH")
+
+  // remove field
+  collection.fields.removeById("_clone_b4SH")
+
+  // remove field
+  collection.fields.removeById("_clone_Ox6G")
+
+  // remove field
+  collection.fields.removeById("_clone_GlyX")
+
+  // remove field
+  collection.fields.removeById("_clone_JhcX")
+
+  // remove field
+  collection.fields.removeById("_clone_P7PF")
+
+  // remove field
+  collection.fields.removeById("_clone_frQS")
+
+  // remove field
+  collection.fields.removeById("_clone_ZfhN")
+
+  // remove field
+  collection.fields.removeById("_clone_h3kj")
+
+  // remove field
+  collection.fields.removeById("_clone_HT55")
+
+  // remove field
+  collection.fields.removeById("_clone_X5Nb")
+
+  // remove field
+  collection.fields.removeById("_clone_nI7O")
+
+  // add field
+  collection.fields.addAt(2, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_NUnv",
+    "max": 0,
+    "min": 0,
+    "name": "child_name",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(3, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_L64g",
+    "max": 0,
+    "min": 0,
+    "name": "child_color",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(4, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_3346940990",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_6VSt",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "group_id",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "relation"
+  }))
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_CDD6",
+    "max": 0,
+    "min": 0,
+    "name": "task_title",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_JwoX",
+    "max": null,
+    "min": null,
+    "name": "task_priority",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(9, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_ONVe",
+    "maxSelect": 1,
+    "name": "task_time_of_day",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "select",
+    "values": [
+      "morning",
+      "afternoon",
+      "evening"
+    ]
+  }))
+
+  // add field
+  collection.fields.addAt(10, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_1bAe",
+    "max": "",
+    "min": "",
+    "name": "task_due_date",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(11, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_urss",
+    "name": "task_completed",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // add field
+  collection.fields.addAt(12, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_GZb7",
+    "max": "",
+    "min": "",
+    "name": "task_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(13, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_fR0P",
+    "max": "",
+    "min": "",
+    "name": "task_last_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(14, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_5xRy",
+    "max": 0,
+    "min": 0,
+    "name": "task_recurrence_type",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(15, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_WCaI",
+    "max": null,
+    "min": 0,
+    "name": "task_points",
+    "onlyInt": true,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(16, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "json2302947054",
+    "maxSize": 1,
+    "name": "task_is_chore",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "json"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4142202888")
+
+  // update collection data
+  unmarshal({
+    "viewQuery": "SELECT\n  (c.id || '-' || COALESCE(t.id, 'none')) AS id,\n  c.id AS child_id,\n  c.name AS child_name,\n  c.color AS child_color,\n  c.\"group\" AS group_id,\n  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child = c.id) AS REAL) AS child_points_balance,\n  t.id AS task_id,\n  t.title AS task_title,\n  t.priority AS task_priority,\n  t.timeOfDay AS task_time_of_day,\n  t.dueDate AS task_due_date,\n  t.completed AS task_completed,\n  t.completedAt AS task_completed_at,\n  t.lastCompletedAt AS task_last_completed_at,\n  t.recurrenceType AS task_recurrence_type,\n  t.points AS task_points\nFROM children c\nLEFT JOIN tasks t ON t.child = c.id"
+  }, collection)
+
+  // add field
+  collection.fields.addAt(2, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_WzuH",
+    "max": 0,
+    "min": 0,
+    "name": "child_name",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(3, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_b4SH",
+    "max": 0,
+    "min": 0,
+    "name": "child_color",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(4, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_3346940990",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_Ox6G",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "group_id",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "relation"
+  }))
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_GlyX",
+    "max": 0,
+    "min": 0,
+    "name": "task_title",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_JhcX",
+    "max": null,
+    "min": null,
+    "name": "task_priority",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(9, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_P7PF",
+    "maxSelect": 1,
+    "name": "task_time_of_day",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "select",
+    "values": [
+      "morning",
+      "afternoon",
+      "evening"
+    ]
+  }))
+
+  // add field
+  collection.fields.addAt(10, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_frQS",
+    "max": "",
+    "min": "",
+    "name": "task_due_date",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(11, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_ZfhN",
+    "name": "task_completed",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // add field
+  collection.fields.addAt(12, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_h3kj",
+    "max": "",
+    "min": "",
+    "name": "task_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(13, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_HT55",
+    "max": "",
+    "min": "",
+    "name": "task_last_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(14, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_X5Nb",
+    "max": 0,
+    "min": 0,
+    "name": "task_recurrence_type",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(15, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_nI7O",
+    "max": null,
+    "min": 0,
+    "name": "task_points",
+    "onlyInt": true,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // remove field
+  collection.fields.removeById("_clone_NUnv")
+
+  // remove field
+  collection.fields.removeById("_clone_L64g")
+
+  // remove field
+  collection.fields.removeById("_clone_6VSt")
+
+  // remove field
+  collection.fields.removeById("_clone_CDD6")
+
+  // remove field
+  collection.fields.removeById("_clone_JwoX")
+
+  // remove field
+  collection.fields.removeById("_clone_ONVe")
+
+  // remove field
+  collection.fields.removeById("_clone_1bAe")
+
+  // remove field
+  collection.fields.removeById("_clone_urss")
+
+  // remove field
+  collection.fields.removeById("_clone_GZb7")
+
+  // remove field
+  collection.fields.removeById("_clone_fR0P")
+
+  // remove field
+  collection.fields.removeById("_clone_5xRy")
+
+  // remove field
+  collection.fields.removeById("_clone_WCaI")
+
+  // remove field
+  collection.fields.removeById("json2302947054")
+
+  return app.save(collection)
+})

--- a/packages/api/pocketbase/pb_migrations/1776919362_updated_tasks_page_view.js
+++ b/packages/api/pocketbase/pb_migrations/1776919362_updated_tasks_page_view.js
@@ -1,0 +1,495 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4142202888")
+
+  // update collection data
+  unmarshal({
+    "viewQuery": "SELECT\n  (c.id || '-' || COALESCE(t.id, 'none')) AS id,\n  c.id AS child_id,\n  c.name AS child_name,\n  c.color AS child_color,\n  c.\"group\" AS group_id,\n  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child = c.id) AS REAL) AS child_points_balance,\n  t.id AS task_id,\n  t.title AS task_title,\n  t.priority AS task_priority,\n  t.timeOfDay AS task_time_of_day,\n  t.dueDate AS task_due_date,\n  t.completed AS task_completed,\n  t.completedAt AS task_completed_at,\n  t.lastCompletedAt AS task_last_completed_at,\n  t.recurrenceType AS task_recurrence_type,\n  t.points AS task_points,\n  t.isChore AS task_is_chore\nFROM children c\nLEFT JOIN tasks t ON t.child = c.id"
+  }, collection)
+
+  // remove field
+  collection.fields.removeById("_clone_NUnv")
+
+  // remove field
+  collection.fields.removeById("_clone_L64g")
+
+  // remove field
+  collection.fields.removeById("_clone_6VSt")
+
+  // remove field
+  collection.fields.removeById("_clone_CDD6")
+
+  // remove field
+  collection.fields.removeById("_clone_JwoX")
+
+  // remove field
+  collection.fields.removeById("_clone_ONVe")
+
+  // remove field
+  collection.fields.removeById("_clone_1bAe")
+
+  // remove field
+  collection.fields.removeById("_clone_urss")
+
+  // remove field
+  collection.fields.removeById("_clone_GZb7")
+
+  // remove field
+  collection.fields.removeById("_clone_fR0P")
+
+  // remove field
+  collection.fields.removeById("_clone_5xRy")
+
+  // remove field
+  collection.fields.removeById("_clone_WCaI")
+
+  // remove field
+  collection.fields.removeById("json2302947054")
+
+  // add field
+  collection.fields.addAt(2, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_COCH",
+    "max": 0,
+    "min": 0,
+    "name": "child_name",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(3, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_Zbyg",
+    "max": 0,
+    "min": 0,
+    "name": "child_color",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(4, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_3346940990",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_chI0",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "group_id",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "relation"
+  }))
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_rpgS",
+    "max": 0,
+    "min": 0,
+    "name": "task_title",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_vHuq",
+    "max": null,
+    "min": null,
+    "name": "task_priority",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(9, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_anaJ",
+    "maxSelect": 1,
+    "name": "task_time_of_day",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "select",
+    "values": [
+      "morning",
+      "afternoon",
+      "evening"
+    ]
+  }))
+
+  // add field
+  collection.fields.addAt(10, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_8iaL",
+    "max": "",
+    "min": "",
+    "name": "task_due_date",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(11, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_VdPf",
+    "name": "task_completed",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // add field
+  collection.fields.addAt(12, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_qS1s",
+    "max": "",
+    "min": "",
+    "name": "task_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(13, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_FUGh",
+    "max": "",
+    "min": "",
+    "name": "task_last_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(14, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_jCxE",
+    "max": 0,
+    "min": 0,
+    "name": "task_recurrence_type",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(15, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_uuMP",
+    "max": null,
+    "min": 0,
+    "name": "task_points",
+    "onlyInt": true,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(16, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_MxDZ",
+    "name": "task_is_chore",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4142202888")
+
+  // update collection data
+  unmarshal({
+    "viewQuery": "SELECT\n  (c.id || '-' || COALESCE(t.id, 'none')) AS id,\n  c.id AS child_id,\n  c.name AS child_name,\n  c.color AS child_color,\n  c.\"group\" AS group_id,\n  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child = c.id) AS REAL) AS child_points_balance,\n  t.id AS task_id,\n  t.title AS task_title,\n  t.priority AS task_priority,\n  t.timeOfDay AS task_time_of_day,\n  t.dueDate AS task_due_date,\n  t.completed AS task_completed,\n  t.completedAt AS task_completed_at,\n  t.lastCompletedAt AS task_last_completed_at,\n  t.recurrenceType AS task_recurrence_type,\n  t.points AS task_points,\n  COALESCE(t.isChore, 0) AS task_is_chore\nFROM children c\nLEFT JOIN tasks t ON t.child = c.id"
+  }, collection)
+
+  // add field
+  collection.fields.addAt(2, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_NUnv",
+    "max": 0,
+    "min": 0,
+    "name": "child_name",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(3, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_L64g",
+    "max": 0,
+    "min": 0,
+    "name": "child_color",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(4, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_3346940990",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_6VSt",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "group_id",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "relation"
+  }))
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_CDD6",
+    "max": 0,
+    "min": 0,
+    "name": "task_title",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": true,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_JwoX",
+    "max": null,
+    "min": null,
+    "name": "task_priority",
+    "onlyInt": false,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(9, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_ONVe",
+    "maxSelect": 1,
+    "name": "task_time_of_day",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "select",
+    "values": [
+      "morning",
+      "afternoon",
+      "evening"
+    ]
+  }))
+
+  // add field
+  collection.fields.addAt(10, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_1bAe",
+    "max": "",
+    "min": "",
+    "name": "task_due_date",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(11, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_urss",
+    "name": "task_completed",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // add field
+  collection.fields.addAt(12, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_GZb7",
+    "max": "",
+    "min": "",
+    "name": "task_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(13, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_fR0P",
+    "max": "",
+    "min": "",
+    "name": "task_last_completed_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  // add field
+  collection.fields.addAt(14, new Field({
+    "autogeneratePattern": "",
+    "help": "",
+    "hidden": false,
+    "id": "_clone_5xRy",
+    "max": 0,
+    "min": 0,
+    "name": "task_recurrence_type",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(15, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "_clone_WCaI",
+    "max": null,
+    "min": 0,
+    "name": "task_points",
+    "onlyInt": true,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "number"
+  }))
+
+  // add field
+  collection.fields.addAt(16, new Field({
+    "help": "",
+    "hidden": false,
+    "id": "json2302947054",
+    "maxSize": 1,
+    "name": "task_is_chore",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "json"
+  }))
+
+  // remove field
+  collection.fields.removeById("_clone_COCH")
+
+  // remove field
+  collection.fields.removeById("_clone_Zbyg")
+
+  // remove field
+  collection.fields.removeById("_clone_chI0")
+
+  // remove field
+  collection.fields.removeById("_clone_rpgS")
+
+  // remove field
+  collection.fields.removeById("_clone_vHuq")
+
+  // remove field
+  collection.fields.removeById("_clone_anaJ")
+
+  // remove field
+  collection.fields.removeById("_clone_8iaL")
+
+  // remove field
+  collection.fields.removeById("_clone_VdPf")
+
+  // remove field
+  collection.fields.removeById("_clone_qS1s")
+
+  // remove field
+  collection.fields.removeById("_clone_FUGh")
+
+  // remove field
+  collection.fields.removeById("_clone_jCxE")
+
+  // remove field
+  collection.fields.removeById("_clone_uuMP")
+
+  // remove field
+  collection.fields.removeById("_clone_MxDZ")
+
+  return app.save(collection)
+})

--- a/packages/frontend/src/actions/index.ts
+++ b/packages/frontend/src/actions/index.ts
@@ -1,12 +1,12 @@
 import { ActionError, defineAction } from 'astro:actions'
 import { z } from 'astro/zod'
-import { completeTask, undoTask } from '@/lib/tasks'
+import { completeTask, deleteTask, undoTask } from '@/lib/tasks'
 
 const errorLabels: Record<string, string> = {
-  'wrong-phase': 'Diese Aufgabe ist gerade nicht dran.',
   'not-yet-due': 'Diese Aufgabe ist noch nicht fällig.',
   'already-completed': 'Diese Aufgabe wurde bereits erledigt.',
   'not-completed-today': 'Diese Aufgabe wurde nicht heute erledigt.',
+  'not-found': 'Diese Aufgabe existiert nicht mehr.',
 }
 
 export const server = {
@@ -53,6 +53,29 @@ export const server = {
         throw new ActionError({
           code: 'BAD_REQUEST',
           message: errorLabels[result.error] || 'Fehler beim Rückgängigmachen.',
+        })
+      }
+
+      return { success: true }
+    },
+  }),
+  deleteTask: defineAction({
+    accept: 'form',
+    input: z.object({
+      taskId: z.string().min(1),
+    }),
+    handler: async (input, context) => {
+      const { pb, user } = context.locals
+      if (!user) {
+        throw new ActionError({ code: 'UNAUTHORIZED', message: 'Nicht angemeldet.' })
+      }
+
+      const result = await deleteTask(pb, input.taskId)
+
+      if (result.error) {
+        throw new ActionError({
+          code: 'BAD_REQUEST',
+          message: errorLabels[result.error] || 'Fehler beim Löschen.',
         })
       }
 

--- a/packages/frontend/src/lib/tasks.test.ts
+++ b/packages/frontend/src/lib/tasks.test.ts
@@ -63,8 +63,8 @@ describe('sortTasks with timezone', () => {
     // 2026-03-13 23:30 UTC = 2026-03-14 in Europe/Berlin
     // A task due on 2026-03-13 is overdue in Berlin on 2026-03-14 local
     const tasks = [
-      { id: '1', title: 'Due today', dueDate: '2026-03-14 00:00:00.000Z', priority: 1, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null },
-      { id: '2', title: 'Overdue', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null },
+      { id: '1', title: 'Due today', dueDate: '2026-03-14 00:00:00.000Z', priority: 1, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false },
+      { id: '2', title: 'Overdue', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false },
     ]
     const sorted = sortTasks(tasks, 'Europe/Berlin', new Date('2026-03-13T23:30:00Z'))
     expect(sorted[0].title).toBe('Overdue')

--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -13,6 +13,7 @@ export interface Task {
   lastCompletedAt: string | null
   completedBy: string | null
   points: number
+  isChore: boolean
 }
 
 export interface Child {
@@ -50,6 +51,7 @@ export interface TasksPageViewRow {
   task_last_completed_at: string
   task_recurrence_type: string
   task_points: number
+  task_is_chore: boolean
 }
 
 export const viewRowToTask = (row: TasksPageViewRow): Task => ({
@@ -67,6 +69,7 @@ export const viewRowToTask = (row: TasksPageViewRow): Task => ({
   lastCompletedAt: row.task_last_completed_at || null,
   completedBy: null,
   points: row.task_points,
+  isChore: !!row.task_is_chore,
 })
 
 export interface ChildTasksSplit {
@@ -261,10 +264,6 @@ export const completeTask = async (
 
   const group = await pb.collection('groups').getOne(groupId)
   const timezone = group.timezone || 'Europe/Berlin'
-  const currentPhase = getCurrentPhase(group.morningEnd, group.eveningStart, timezone)
-  if (task.timeOfDay !== currentPhase) {
-    return { error: 'wrong-phase' }
-  }
 
   if (task.dueDate) {
     const dueDateStr = task.dueDate.slice(0, 10)
@@ -341,12 +340,24 @@ export const undoTask = async (
   return {}
 }
 
+export const deleteTask = async (
+  pb: import('pocketbase').default,
+  taskId: string,
+): Promise<{ error?: string }> => {
+  try {
+    await pb.collection('tasks').delete(taskId)
+    return {}
+  } catch {
+    return { error: 'not-found' }
+  }
+}
+
 export const sortTasks = (tasks: Task[], timezone?: string, now?: Date): Task[] => {
   const tz = timezone || 'Europe/Berlin'
   const todayStr = getLocalDateString(tz, now || new Date())
   return tasks.sort((a, b) => {
-    const overdueA = a.dueDate && a.dueDate.slice(0, 10) < todayStr ? 1 : 0
-    const overdueB = b.dueDate && b.dueDate.slice(0, 10) < todayStr ? 1 : 0
+    const overdueA = !a.isChore && a.dueDate && a.dueDate.slice(0, 10) < todayStr ? 1 : 0
+    const overdueB = !b.isChore && b.dueDate && b.dueDate.slice(0, 10) < todayStr ? 1 : 0
     if (overdueA !== overdueB) return overdueB - overdueA
 
     const priorityA = (a.priority === null || a.priority === undefined || a.priority === 0) ? Infinity : a.priority

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -223,7 +223,7 @@ const buildPhaseHref = (phase: string) => {
               ) : (
                 <ul class="space-y-3">
                   {tasks.map((task) => {
-                    const isOverdue = task.dueDate && task.dueDate.slice(0, 10) < todayStr
+                    const isOverdue = !task.isChore && task.dueDate && task.dueDate.slice(0, 10) < todayStr
                     return (
                       <li
                         data-testid="task-item"
@@ -258,6 +258,24 @@ const buildPhaseHref = (phase: string) => {
                             <span data-testid="task-points" class="badge badge-warning badge-sm ml-2">+{task.points}</span>
                           )}
                         </div>
+                        <form
+                          method="POST"
+                          action={actions.deleteTask}
+                          data-testid="delete-form"
+                          data-delete-task-title={task.title}
+                        >
+                          <input type="hidden" name="taskId" value={task.id} />
+                          <button
+                            type="submit"
+                            data-testid="delete-button"
+                            class="btn btn-circle btn-ghost btn-sm text-error opacity-60 hover:opacity-100 transition-opacity"
+                            aria-label={`${task.title} löschen`}
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                            </svg>
+                          </button>
+                        </form>
                       </li>
                     )
                   })}
@@ -280,7 +298,7 @@ const buildPhaseHref = (phase: string) => {
                           <span class="text-lg line-through">{task.title}</span>
                           <span class="badge badge-sm badge-outline ml-2">{phaseLabels[task.timeOfDay]}</span>
                         </div>
-                        <form method="POST" action={actions.undoTask}>
+                        <form method="POST" action={actions.undoTask} data-undo-form>
                           <input type="hidden" name="taskId" value={task.id} />
                           <button
                             type="submit"
@@ -366,6 +384,20 @@ const buildPhaseHref = (phase: string) => {
     </form>
   </dialog>
 
+  <dialog data-testid="delete-confirm-dialog" id="delete-confirm-dialog" class="modal">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">Aufgabe löschen?</h3>
+      <p class="py-4">Willst du <strong id="delete-confirm-task-title"></strong> wirklich löschen?</p>
+      <div class="modal-action">
+        <button data-testid="delete-confirm-cancel" id="delete-confirm-cancel" class="btn">Abbrechen</button>
+        <button data-testid="delete-confirm-ok" id="delete-confirm-ok" class="btn btn-error">Löschen</button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+
   <script>
     document.addEventListener('astro:page-load', () => {
       let pendingForm: HTMLFormElement | null = null
@@ -373,6 +405,12 @@ const buildPhaseHref = (phase: string) => {
       const titleEl = document.getElementById('confirm-task-title') as HTMLElement
       const cancelBtn = document.getElementById('confirm-cancel') as HTMLButtonElement
       const okBtn = document.getElementById('confirm-ok') as HTMLButtonElement
+
+      let pendingDeleteForm: HTMLFormElement | null = null
+      const deleteDialog = document.getElementById('delete-confirm-dialog') as HTMLDialogElement
+      const deleteTitleEl = document.getElementById('delete-confirm-task-title') as HTMLElement
+      const deleteCancelBtn = document.getElementById('delete-confirm-cancel') as HTMLButtonElement
+      const deleteOkBtn = document.getElementById('delete-confirm-ok') as HTMLButtonElement
 
       if (!dialog || !titleEl || !cancelBtn || !okBtn) return
 
@@ -394,9 +432,32 @@ const buildPhaseHref = (phase: string) => {
         if (pendingForm) pendingForm.submit()
       })
 
+      if (deleteDialog && deleteTitleEl && deleteCancelBtn && deleteOkBtn) {
+        document.querySelectorAll('form[data-delete-task-title]').forEach((form) => {
+          form.addEventListener('submit', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            pendingDeleteForm = form as HTMLFormElement
+            deleteTitleEl.textContent = form.getAttribute('data-delete-task-title') || ''
+            deleteDialog.showModal()
+          })
+        })
+
+        deleteCancelBtn.addEventListener('click', () => {
+          pendingDeleteForm = null
+          deleteDialog.close()
+        })
+
+        deleteOkBtn.addEventListener('click', () => {
+          if (pendingDeleteForm) pendingDeleteForm.submit()
+        })
+      }
+
       document.querySelectorAll('[data-testid="task-item"]').forEach((li) => {
         li.addEventListener('click', (e) => {
-          if ((e.target as Element).closest('button')) return
+          const target = e.target as Element
+          if (target.closest('button')) return
+          if (target.closest('form[data-delete-task-title]')) return
           const form = li.querySelector('form[data-task-title]') as HTMLFormElement
           if (form) {
             const event = new Event('submit', { cancelable: true, bubbles: true })
@@ -453,5 +514,41 @@ const buildPhaseHref = (phase: string) => {
         })
       })
     })
+  </script>
+
+  <script is:inline data-scroll-preservation>
+    (function () {
+      var KEY = 'task-page-scroll-y'
+
+      function saveScroll() {
+        try { sessionStorage.setItem(KEY, String(window.scrollY)) } catch (_) {}
+      }
+
+      function restoreScroll() {
+        try {
+          var saved = sessionStorage.getItem(KEY)
+          if (saved === null) return
+          sessionStorage.removeItem(KEY)
+          var y = parseInt(saved, 10)
+          if (!isNaN(y)) window.scrollTo(0, y)
+        } catch (_) {}
+      }
+
+      if ('scrollRestoration' in history) history.scrollRestoration = 'manual'
+
+      document.addEventListener('submit', function (e) {
+        var form = e.target
+        if (!form || !(form instanceof HTMLFormElement)) return
+        if (form.hasAttribute('data-task-title') ||
+            form.hasAttribute('data-delete-task-title') ||
+            form.getAttribute('action') && form.getAttribute('action').indexOf('undoTask') !== -1) {
+          saveScroll()
+        }
+      }, true)
+
+      document.addEventListener('astro:before-preparation', saveScroll)
+      document.addEventListener('astro:page-load', restoreScroll)
+      window.addEventListener('pageshow', restoreScroll)
+    })()
   </script>
 </Layout>

--- a/packages/frontend/tests/pages/group/chores.integration.test.ts
+++ b/packages/frontend/tests/pages/group/chores.integration.test.ts
@@ -1,0 +1,157 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import PocketBase from 'pocketbase'
+import request from 'supertest'
+import { app } from '@family-todo/mcp/src/server.js'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { resetPocketBase } from '@/lib/pocketbase'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+const mcpCall = (token: string, toolName: string, args: Record<string, unknown>) =>
+  request(app)
+    .post('/mcp')
+    .query({ token })
+    .send({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+      id: 1,
+    })
+    .then((res) => res.body)
+
+const extractId = (text: string) => text.match(/ID: ([a-z0-9]+)/)?.[1] ?? ''
+
+const travelTo = (datetime: string) => vi.setSystemTime(new Date(datetime))
+
+describe('Chore Tasks Integration Tests', () => {
+  let authToken: string
+  let userPb: PocketBase
+  let adminPb: PocketBase
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    resetPocketBase()
+
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb
+      .collection('_superusers')
+      .authWithPassword('admin@test.local', 'testtest123')
+
+    const email = `test-${Date.now()}@example.com`
+    await adminPb.collection('users').create({
+      email,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+    })
+
+    userPb = new PocketBase(POCKETBASE_URL)
+    await userPb.collection('users').authWithPassword(email, 'testtest123')
+    authToken = userPb.authStore.token
+
+    container = await AstroContainer.create()
+
+    const groupResult = await mcpCall(authToken, 'create_group', { name: 'Test Family' })
+    groupId = extractId(groupResult.result.content[0].text)
+
+    const childResult = await mcpCall(authToken, 'create_child', {
+      groupId,
+      name: 'TestKind',
+      color: '#FF6B6B',
+    })
+    childId = extractId(childResult.result.content[0].text)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const createTask = (overrides: Record<string, unknown> = {}) =>
+    mcpCall(authToken, 'create_task', {
+      childId,
+      title: 'Test Task',
+      timeOfDay: 'morning',
+      priority: 1,
+      ...overrides,
+    }).then((r) => extractId(r.result.content[0].text))
+
+  const renderPage = () =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { pb: userPb, user: userPb.authStore.record },
+      request: new Request(`http://localhost/group/${groupId}/tasks?child=${childId}`),
+    })
+
+  describe('Chore tasks are never marked overdue', () => {
+    it('chore task with past dueDate does NOT show overdue badge', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'Zähne putzen',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-08',
+        isChore: true,
+      })
+
+      const html = await renderPage()
+      expect(html).toContain('Zähne putzen')
+      expect(html).not.toContain('data-overdue="true"')
+      expect(html).not.toContain('Überfällig')
+    })
+
+    it('non-chore task with past dueDate DOES show overdue badge', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'Hausaufgaben',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-08',
+      })
+
+      const html = await renderPage()
+      expect(html).toContain('Hausaufgaben')
+      expect(html).toContain('data-overdue="true"')
+    })
+
+    it('chore task appears next day without being marked overdue', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'Bett machen',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+        isChore: true,
+      })
+
+      // Next day: task was never completed
+      travelTo('2026-03-11T07:00:00Z')
+      const html = await renderPage()
+      expect(html).toContain('Bett machen')
+      expect(html).not.toContain('Überfällig')
+      expect(html).not.toContain('data-overdue="true"')
+    })
+
+    it('chore task does not sort before non-chore tasks due to overdue status', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'NormalePrio1',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+        priority: 1,
+      })
+      await createTask({
+        title: 'ChorePrio2',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-08', // Past due but chore
+        priority: 2,
+        isChore: true,
+      })
+
+      const html = await renderPage()
+      const normalPos = html.indexOf('NormalePrio1')
+      const chorePos = html.indexOf('ChorePrio2')
+      // Normal task should come first (lower priority number), chore should not jump to top
+      expect(normalPos).toBeLessThan(chorePos)
+    })
+  })
+})

--- a/packages/frontend/tests/pages/group/delete-task.integration.test.ts
+++ b/packages/frontend/tests/pages/group/delete-task.integration.test.ts
@@ -1,0 +1,181 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import PocketBase from 'pocketbase'
+import request from 'supertest'
+import { app } from '@family-todo/mcp/src/server.js'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { deleteTask } from '../../../src/lib/tasks'
+import { resetPocketBase } from '@/lib/pocketbase'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+const mcpCall = (token: string, toolName: string, args: Record<string, unknown>) =>
+  request(app)
+    .post('/mcp')
+    .query({ token })
+    .send({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+      id: 1,
+    })
+    .then((res) => res.body)
+
+const extractId = (text: string) => text.match(/ID: ([a-z0-9]+)/)?.[1] ?? ''
+
+const travelTo = (datetime: string) => vi.setSystemTime(new Date(datetime))
+
+describe('Delete Task Integration Tests', () => {
+  let authToken: string
+  let userPb: PocketBase
+  let adminPb: PocketBase
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    resetPocketBase()
+
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb
+      .collection('_superusers')
+      .authWithPassword('admin@test.local', 'testtest123')
+
+    const email = `test-${Date.now()}@example.com`
+    await adminPb.collection('users').create({
+      email,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+    })
+
+    userPb = new PocketBase(POCKETBASE_URL)
+    await userPb.collection('users').authWithPassword(email, 'testtest123')
+    authToken = userPb.authStore.token
+
+    container = await AstroContainer.create()
+
+    const groupResult = await mcpCall(authToken, 'create_group', {
+      name: 'Test Family',
+    })
+    groupId = extractId(groupResult.result.content[0].text)
+
+    const childResult = await mcpCall(authToken, 'create_child', {
+      groupId,
+      name: 'TestKind',
+      color: '#FF6B6B',
+    })
+    childId = extractId(childResult.result.content[0].text)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const createTask = (overrides: Record<string, unknown> = {}) =>
+    mcpCall(authToken, 'create_task', {
+      childId,
+      title: 'Test Task',
+      timeOfDay: 'morning',
+      priority: 1,
+      ...overrides,
+    }).then((r) => extractId(r.result.content[0].text))
+
+  const renderPage = () =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { pb: userPb, user: userPb.authStore.record },
+      request: new Request(
+        `http://localhost/group/${groupId}/tasks?child=${childId}`,
+      ),
+    })
+
+  const doDeleteTask = (taskId: string) => deleteTask(userPb, taskId)
+
+  const getTaskSafe = async (taskId: string) => {
+    try {
+      return await adminPb.collection('tasks').getOne(taskId)
+    } catch {
+      return null
+    }
+  }
+
+  describe('deleteTask function', () => {
+    it('deletes a task from PocketBase', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      const taskId = await createTask({
+        title: 'Unwichtig',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+      })
+
+      expect(await getTaskSafe(taskId)).not.toBeNull()
+
+      const result = await doDeleteTask(taskId)
+
+      expect(result.error).toBeUndefined()
+      expect(await getTaskSafe(taskId)).toBeNull()
+    })
+
+    it('deletes a task regardless of phase', async () => {
+      travelTo('2026-03-10T13:00:00Z')
+      const taskId = await createTask({
+        title: 'Abendaufgabe',
+        timeOfDay: 'evening',
+        dueDate: '2026-03-10',
+      })
+
+      const result = await doDeleteTask(taskId)
+
+      expect(result.error).toBeUndefined()
+      expect(await getTaskSafe(taskId)).toBeNull()
+    })
+
+    it('returns not-found error when task does not exist', async () => {
+      const result = await doDeleteTask('nonexistentid1')
+      expect(result.error).toBe('not-found')
+    })
+  })
+
+  describe('UI: delete button', () => {
+    it('renders a delete (trash) button on each active task', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'Löschbar',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+      })
+
+      const html = await renderPage()
+
+      expect(html).toContain('data-testid="delete-button"')
+    })
+
+    it('delete button form posts to deleteTask action with taskId', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      const taskId = await createTask({
+        title: 'Löschbar',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+      })
+
+      const html = await renderPage()
+
+      expect(html).toContain('data-testid="delete-form"')
+      expect(html).toContain(`value="${taskId}"`)
+    })
+
+    it('renders a delete-confirm dialog for the page', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      await createTask({
+        title: 'Löschbar',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-10',
+      })
+
+      const html = await renderPage()
+
+      expect(html).toContain('data-testid="delete-confirm-dialog"')
+    })
+  })
+})

--- a/packages/frontend/tests/pages/group/scroll-preservation.integration.test.ts
+++ b/packages/frontend/tests/pages/group/scroll-preservation.integration.test.ts
@@ -1,0 +1,95 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import PocketBase from 'pocketbase'
+import request from 'supertest'
+import { app } from '@family-todo/mcp/src/server.js'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { resetPocketBase } from '@/lib/pocketbase'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+const mcpCall = (token: string, toolName: string, args: Record<string, unknown>) =>
+  request(app)
+    .post('/mcp')
+    .query({ token })
+    .send({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+      id: 1,
+    })
+    .then((res) => res.body)
+
+const extractId = (text: string) => text.match(/ID: ([a-z0-9]+)/)?.[1] ?? ''
+
+describe('Scroll Position Preservation', () => {
+  let authToken: string
+  let userPb: PocketBase
+  let adminPb: PocketBase
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-03-10T07:00:00Z'))
+    resetPocketBase()
+
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb
+      .collection('_superusers')
+      .authWithPassword('admin@test.local', 'testtest123')
+
+    const email = `test-${Date.now()}@example.com`
+    await adminPb.collection('users').create({
+      email,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+    })
+
+    userPb = new PocketBase(POCKETBASE_URL)
+    await userPb.collection('users').authWithPassword(email, 'testtest123')
+    authToken = userPb.authStore.token
+
+    container = await AstroContainer.create()
+
+    const groupResult = await mcpCall(authToken, 'create_group', { name: 'Test Family' })
+    groupId = extractId(groupResult.result.content[0].text)
+
+    const childResult = await mcpCall(authToken, 'create_child', {
+      groupId,
+      name: 'TestKind',
+      color: '#FF6B6B',
+    })
+    childId = extractId(childResult.result.content[0].text)
+
+    await mcpCall(authToken, 'create_task', {
+      childId,
+      title: 'A Task',
+      timeOfDay: 'morning',
+      priority: 1,
+      dueDate: '2026-03-10',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const renderPage = () =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { pb: userPb, user: userPb.authStore.record },
+      request: new Request(`http://localhost/group/${groupId}/tasks?child=${childId}`),
+    })
+
+  it('includes scroll-preservation script that saves scroll position', async () => {
+    const html = await renderPage()
+    expect(html).toContain('data-scroll-preservation')
+  })
+
+  it('uses sessionStorage key for task-page scroll position', async () => {
+    const html = await renderPage()
+    expect(html).toContain('task-page-scroll-y')
+  })
+})

--- a/packages/frontend/tests/pages/group/time-travel.integration.test.ts
+++ b/packages/frontend/tests/pages/group/time-travel.integration.test.ts
@@ -782,7 +782,7 @@ describe('Time-Travel Integration Tests', () => {
   // ====== H. Server Validation ======
 
   describe('H. Server Validation', () => {
-    it('cannot complete morning task when it is afternoon → error', async () => {
+    it('completes morning task when it is afternoon (no phase restriction)', async () => {
       travelTo('2026-03-10T06:00:00Z')
       const taskId = await createTask({
         title: 'Morgenaufgabe',
@@ -792,10 +792,12 @@ describe('Time-Travel Integration Tests', () => {
 
       travelTo('2026-03-10T13:00:00Z')
       const result = await doCompleteTask(taskId)
-      expect(result.error).toBe('wrong-phase')
+      expect(result.error).toBeUndefined()
+      const task = await getTask(taskId)
+      expect(task.completed).toBe(true)
     })
 
-    it('cannot complete evening task when it is morning → error', async () => {
+    it('completes evening task when it is morning (no phase restriction)', async () => {
       travelTo('2026-03-10T19:00:00Z')
       const taskId = await createTask({
         title: 'Abendaufgabe',
@@ -805,7 +807,9 @@ describe('Time-Travel Integration Tests', () => {
 
       travelTo('2026-03-10T06:00:00Z')
       const result = await doCompleteTask(taskId)
-      expect(result.error).toBe('wrong-phase')
+      expect(result.error).toBeUndefined()
+      const task = await getTask(taskId)
+      expect(task.completed).toBe(true)
     })
 
     it('cannot complete task with dueDate=tomorrow → error', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -422,11 +422,12 @@ function registerTools() {
       recurrenceInterval: z.number().optional().describe('Days between recurrences (for interval type)'),
       recurrenceDays: z.array(z.number()).optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday)'),
       points: z.number().optional().describe('Points awarded for completing this task'),
+      isChore: z.boolean().optional().describe('If true, task never shows as overdue and silently rolls over to the next day if not completed'),
     }),
     handler: async (args, pb) => {
-      const { childId, title, timeOfDay, priority, dueDate, recurrenceType, recurrenceInterval, recurrenceDays, points } = args as {
+      const { childId, title, timeOfDay, priority, dueDate, recurrenceType, recurrenceInterval, recurrenceDays, points, isChore } = args as {
         childId: string; title: string; timeOfDay: string; priority?: number; dueDate?: string;
-        recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]; points?: number
+        recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]; points?: number; isChore?: boolean
       }
 
       const child = await pb.collection('children').getOne(childId)
@@ -447,6 +448,7 @@ function registerTools() {
         recurrenceInterval: recurrenceInterval ?? null,
         recurrenceDays: recurrenceDays ?? null,
         points: points ?? null,
+        isChore: isChore ?? false,
       })
 
       const parts = [`Created task "${title}" (ID: ${task.id})`]
@@ -466,15 +468,17 @@ function registerTools() {
       priority: z.number().optional().describe('New priority'),
       childId: z.string().optional().describe('Reassign to different child'),
       timeOfDay: z.enum(['morning', 'afternoon', 'evening']).optional().describe('Time of day phase'),
+      isChore: z.boolean().optional().describe('Mark/unmark as chore (never overdue, silent rollover)'),
     }),
     handler: async (args, pb) => {
-      const { taskId, title, priority, childId, timeOfDay } = args as { taskId: string; title?: string; priority?: number; childId?: string; timeOfDay?: string }
+      const { taskId, title, priority, childId, timeOfDay, isChore } = args as { taskId: string; title?: string; priority?: number; childId?: string; timeOfDay?: string; isChore?: boolean }
 
       const updates: Record<string, unknown> = {}
       if (title) updates.title = title
       if (priority !== undefined) updates.priority = priority
       if (childId) updates.child = childId
       if (timeOfDay) updates.timeOfDay = timeOfDay
+      if (isChore !== undefined) updates.isChore = isChore
 
       await pb.collection('tasks').update(taskId, updates)
 


### PR DESCRIPTION
- Drop "wrong-phase" server check: kids can complete any today-task
  regardless of current phase (morning task in the evening, etc.)
- Add delete button (trash icon) with its own confirmation dialog;
  card click still triggers complete, trash click only deletes
- Preserve scroll position across completion/delete/undo form submits
  via sessionStorage + astro:page-load restore
- Add isChore flag on tasks: chores never render as overdue and no
  longer sort to the top, so they silently reappear the next day
  without the "Überfällig" badge pressuring kids
- Expose isChore via create_task / update_task MCP tools
- Regenerate tasks_page_view with task_is_chore column

https://claude.ai/code/session_0151X2GvMBdynHdLe689MbPm