### PR TITLE
Skip only current instance when deleting recurring tasks

### DIFF
--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -343,8 +343,26 @@ export const undoTask = async (
 export const deleteTask = async (
   pb: import('pocketbase').default,
   taskId: string,
+  timezone?: string,
 ): Promise<{ error?: string }> => {
   try {
+    const task = await pb.collection('tasks').getOne(taskId)
+
+    if (task.recurrenceType && task.dueDate) {
+      const baseDate = new Date(task.dueDate.slice(0, 10) + 'T00:00:00Z')
+      const nextDueDate = calculateNextDueDate(
+        task.recurrenceType,
+        task.recurrenceInterval,
+        task.recurrenceDays,
+        baseDate,
+        timezone,
+      )
+      if (nextDueDate) {
+        await pb.collection('tasks').update(taskId, { dueDate: nextDueDate })
+        return {}
+      }
+    }
+
     await pb.collection('tasks').delete(taskId)
     return {}
   } catch {

--- a/packages/frontend/tests/pages/group/delete-task.integration.test.ts
+++ b/packages/frontend/tests/pages/group/delete-task.integration.test.ts
@@ -136,6 +136,53 @@ describe('Delete Task Integration Tests', () => {
       const result = await doDeleteTask('nonexistentid1')
       expect(result.error).toBe('not-found')
     })
+
+    it('skips only the current instance of an interval-recurring task', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      const taskId = await createTask({
+        title: 'Müll rausbringen',
+        timeOfDay: 'morning',
+        dueDate: '2026-03-09',
+        recurrenceType: 'interval',
+        recurrenceInterval: 2,
+      })
+
+      travelTo('2026-03-10T07:00:00Z')
+      const result = await doDeleteTask(taskId)
+
+      expect(result.error).toBeUndefined()
+
+      const task = await getTaskSafe(taskId)
+      expect(task).not.toBeNull()
+      expect(task?.dueDate?.slice(0, 10)).toBe('2026-03-11')
+      expect(task?.recurrenceType).toBe('interval')
+      expect(task?.recurrenceInterval).toBe(2)
+      expect(task?.lastCompletedAt).toBeFalsy()
+      expect(task?.completed).toBe(false)
+    })
+
+    it('skips only the current instance of a weekly-recurring task', async () => {
+      travelTo('2026-03-10T07:00:00Z')
+      const taskId = await createTask({
+        title: 'Klavier üben',
+        timeOfDay: 'afternoon',
+        dueDate: '2026-03-09',
+        recurrenceType: 'weekly',
+        recurrenceDays: [1, 3, 5],
+      })
+
+      travelTo('2026-03-10T07:00:00Z')
+      const result = await doDeleteTask(taskId)
+
+      expect(result.error).toBeUndefined()
+
+      const task = await getTaskSafe(taskId)
+      expect(task).not.toBeNull()
+      expect(task?.dueDate?.slice(0, 10)).toBe('2026-03-11')
+      expect(task?.recurrenceType).toBe('weekly')
+      expect(task?.lastCompletedAt).toBeFalsy()
+      expect(task?.completed).toBe(false)
+    })
   })
 
   describe('UI: delete button', () => {


### PR DESCRIPTION
Previously, deleting a recurring task removed the entire series.
Now, for tasks with a recurrence rule, deletion advances dueDate
by one interval (or to the next configured weekday) so only the
current overdue instance is skipped while the schedule continues.

Non-recurring tasks are still hard-deleted.