### PR TITLE
Remove the &quot;Überfällig&quot; (overdue) feature entirely

### DIFF
--- a/packages/frontend/src/lib/tasks.test.ts
+++ b/packages/frontend/src/lib/tasks.test.ts
@@ -58,15 +58,15 @@ describe('getCurrentPhase with timezone', () => {
   })
 })
 
-describe('sortTasks with timezone', () => {
-  it('should use timezone for overdue detection', () => {
-    // 2026-03-13 23:30 UTC = 2026-03-14 in Europe/Berlin
-    // A task due on 2026-03-13 is overdue in Berlin on 2026-03-14 local
+describe('sortTasks', () => {
+  it('sorts purely by priority and does NOT hoist past-due tasks', () => {
+    // The overdue feature was removed: a past-due task must not jump ahead of a
+    // higher-priority task just because its due date is in the past.
     const tasks = [
       { id: '1', title: 'Due today', dueDate: '2026-03-14 00:00:00.000Z', priority: 1, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false },
-      { id: '2', title: 'Overdue', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false },
+      { id: '2', title: 'Past due', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false },
     ]
     const sorted = sortTasks(tasks, 'Europe/Berlin', new Date('2026-03-13T23:30:00Z'))
-    expect(sorted[0].title).toBe('Overdue')
+    expect(sorted[0].title).toBe('Due today')
   })
 })

--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -397,14 +397,11 @@ export const deleteTask = async (
   }
 }
 
-export const sortTasks = (tasks: Task[], timezone?: string, now?: Date): Task[] => {
-  const tz = timezone || 'Europe/Berlin'
-  const todayStr = getLocalDateString(tz, now || new Date())
+// Sorts purely by priority. The "overdue" concept was removed, so past-due
+// tasks are no longer hoisted to the top. (timezone/now are kept for call-site
+// compatibility but are no longer needed.)
+export const sortTasks = (tasks: Task[], _timezone?: string, _now?: Date): Task[] => {
   return tasks.sort((a, b) => {
-    const overdueA = !a.isChore && !a.dailyOnly && a.dueDate && a.dueDate.slice(0, 10) < todayStr ? 1 : 0
-    const overdueB = !b.isChore && !b.dailyOnly && b.dueDate && b.dueDate.slice(0, 10) < todayStr ? 1 : 0
-    if (overdueA !== overdueB) return overdueB - overdueA
-
     const priorityA = (a.priority === null || a.priority === undefined || a.priority === 0) ? Infinity : a.priority
     const priorityB = (b.priority === null || b.priority === undefined || b.priority === 0) ? Infinity : b.priority
     return priorityA - priorityB

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -72,7 +72,6 @@ const selectedSplit = selectedChildId
   : null
 const selectedChild: Child | null = selectedSplit?.child ?? null
 
-const todayStr = getLocalDateString(groupTimezone)
 const showSwitcher = selectedChild && children.length > 1
 const displaySplits = selectedSplit ? [selectedSplit] : childSplits
 const displayChildren: Child[] = displaySplits.map((s) => s.child)
@@ -245,14 +244,12 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
               ) : (
                 <ul class="space-y-3">
                   {tasks.map((task) => {
-                    const isOverdue = !task.isChore && !task.dailyOnly && task.dueDate && task.dueDate.slice(0, 10) < todayStr
                     return (
                       <li
                         data-testid="task-item"
-                        data-overdue={isOverdue ? "true" : undefined}
                         class:list={[
                           'flex items-center gap-4 p-4 rounded-xl min-h-[56px] transition-transform duration-150 active:scale-[0.97] hover:shadow-md cursor-pointer',
-                          isOverdue ? 'bg-error/10 border-2 border-error' : 'bg-base-200',
+                          'bg-base-200',
                         ]}
                       >
                         <form method="POST" action={`${actions.completeTask}${actionSuffix}`} data-task-title={task.title}>
@@ -273,9 +270,6 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                         </form>
                         <div class="flex-1">
                           <span class="text-xl md:text-2xl">{task.title}</span>
-                          {isOverdue && (
-                            <span data-testid="overdue-badge" class="badge badge-error badge-sm ml-2">Überfällig</span>
-                          )}
                           {task.points > 0 && (
                             <span data-testid="task-points" class="badge badge-warning badge-sm ml-2">+{task.points}</span>
                           )}

--- a/packages/frontend/tests/pages/group/chores.integration.test.ts
+++ b/packages/frontend/tests/pages/group/chores.integration.test.ts
@@ -102,7 +102,7 @@ describe('Chore Tasks Integration Tests', () => {
       expect(html).not.toContain('Überfällig')
     })
 
-    it('non-chore task with past dueDate DOES show overdue badge', async () => {
+    it('non-chore task with past dueDate still shows, but is not marked overdue', async () => {
       travelTo('2026-03-10T07:00:00Z')
       await createTask({
         title: 'Hausaufgaben',
@@ -112,7 +112,8 @@ describe('Chore Tasks Integration Tests', () => {
 
       const html = await renderPage()
       expect(html).toContain('Hausaufgaben')
-      expect(html).toContain('data-overdue="true"')
+      expect(html).not.toContain('data-overdue="true"')
+      expect(html).not.toContain('Überfällig')
     })
 
     it('chore task appears next day without being marked overdue', async () => {

--- a/packages/frontend/tests/pages/group/daily-only.integration.test.ts
+++ b/packages/frontend/tests/pages/group/daily-only.integration.test.ts
@@ -99,7 +99,7 @@ describe('Daily-only (Tagesaufgaben) tasks', () => {
     expect(html).not.toContain('Unkraut jaeten')
   })
 
-  it('still carries forward a normal (non daily-only) task that is overdue', async () => {
+  it('still carries forward a normal (non daily-only) past-due task, without marking it overdue', async () => {
     await adminPb.collection('tasks').create({
       title: 'Normale Aufgabe',
       child: childId,
@@ -111,7 +111,10 @@ describe('Daily-only (Tagesaufgaben) tasks', () => {
 
     const html = await render()
 
+    // A normal task still carries forward (stays visible)...
     expect(html).toContain('Normale Aufgabe')
-    expect(html).toContain('data-overdue="true"')
+    // ...but the overdue feature was removed, so it is never flagged.
+    expect(html).not.toContain('data-overdue="true"')
+    expect(html).not.toContain('Überfällig')
   })
 })

--- a/packages/frontend/tests/pages/group/mcp-to-frontend.integration.test.ts
+++ b/packages/frontend/tests/pages/group/mcp-to-frontend.integration.test.ts
@@ -207,7 +207,7 @@ describe('MCP → Frontend Integration', () => {
     expect(html).not.toContain('Andere Phase')
   })
 
-  it('should show overdue recurring task created via MCP', async () => {
+  it('shows a past-due recurring task created via MCP without an overdue marker', async () => {
     const groupResult = await mcpCall(authToken, 'create_group', { name: 'Overdue Family' })
     const groupId = extractId(groupResult.result.content[0].text)
 
@@ -225,7 +225,7 @@ describe('MCP → Frontend Integration', () => {
 
     await mcpCall(authToken, 'create_task', {
       childId,
-      title: 'Überfällige Aufgabe',
+      title: 'Gestrige Aufgabe',
       priority: 1,
       timeOfDay: currentPhase,
       recurrenceType: 'interval',
@@ -235,8 +235,8 @@ describe('MCP → Frontend Integration', () => {
 
     const html = await renderChildPage(groupId, childId)
 
-    expect(html).toContain('Überfällige Aufgabe')
-    expect(html).toContain('data-overdue="true"')
-    expect(html).toContain('Überfällig')
+    expect(html).toContain('Gestrige Aufgabe')
+    expect(html).not.toContain('data-overdue="true"')
+    expect(html).not.toContain('data-testid="overdue-badge"')
   })
 })

--- a/packages/frontend/tests/pages/group/no-overdue.integration.test.ts
+++ b/packages/frontend/tests/pages/group/no-overdue.integration.test.ts
@@ -8,7 +8,9 @@ import { authUser } from '../../helpers'
 const POCKETBASE_URL =
   process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
 
-describe('Overdue display on overview page', () => {
+// The "Überfällig" (overdue) feature was removed entirely: past-due tasks must
+// still be shown (so they can be completed) but must NEVER be flagged overdue.
+describe('No overdue marking', () => {
   let pb: PocketBase
   let adminPb: PocketBase
   let container: AstroContainer
@@ -27,26 +29,20 @@ describe('Overdue display on overview page', () => {
 
     pb = new PocketBase(POCKETBASE_URL)
     const user = await adminPb.collection('users').create({
-      email: `overdue-overview-${Date.now()}@test.local`,
+      email: `no-overdue-${Date.now()}@test.local`,
       password: 'testtest123',
       passwordConfirm: 'testtest123',
       name: 'Test User',
     })
-    await pb
-      .collection('users')
-      .authWithPassword(user.email, 'testtest123')
+    await pb.collection('users').authWithPassword(user.email, 'testtest123')
 
     const group = await adminPb.collection('groups').create({
-      name: 'Overdue Test Family',
+      name: 'No Overdue Family',
       morningEnd: '00:00',
       eveningStart: '23:59',
     })
     groupId = group.id
-
-    await adminPb.collection('user_groups').create({
-      user: user.id,
-      group: groupId,
-    })
+    await adminPb.collection('user_groups').create({ user: user.id, group: groupId })
 
     const child = await adminPb.collection('children').create({
       name: 'Anna',
@@ -62,40 +58,28 @@ describe('Overdue display on overview page', () => {
     vi.useRealTimers()
   })
 
-  it('should NOT mark a task due today as overdue on the overview page', async () => {
-    await adminPb.collection('tasks').create({
-      title: 'Task Due Today',
-      child: childId,
-      completed: false,
-      timeOfDay: 'afternoon',
-      dueDate: '2026-03-13',
-    })
-
-    const html = await container.renderToString(TasksPage, {
+  const render = () =>
+    container.renderToString(TasksPage, {
       params: { groupId },
       locals: { pb, user: authUser(pb) },
     })
 
-    expect(html).toContain('Task Due Today')
-    expect(html).not.toContain('data-overdue="true"')
-  })
-
-  it('shows a task due yesterday on the overview page but does NOT mark it overdue', async () => {
+  it('shows a past-due task but never marks it as überfällig', async () => {
     await adminPb.collection('tasks').create({
-      title: 'Task Due Yesterday',
+      title: 'Duschen',
       child: childId,
       completed: false,
       timeOfDay: 'afternoon',
-      dueDate: '2026-03-12',
+      dueDate: '2026-03-12', // yesterday
     })
 
-    const html = await container.renderToString(TasksPage, {
-      params: { groupId },
-      locals: { pb, user: authUser(pb) },
-    })
+    const html = await render()
 
-    expect(html).toContain('Task Due Yesterday')
+    // The task is still visible so it can be done...
+    expect(html).toContain('Duschen')
+    // ...but the overdue feature is gone entirely.
     expect(html).not.toContain('data-overdue="true"')
+    expect(html).not.toContain('data-testid="overdue-badge"')
     expect(html).not.toContain('Überfällig')
   })
 })

--- a/packages/frontend/tests/pages/group/tasks.integration.test.ts
+++ b/packages/frontend/tests/pages/group/tasks.integration.test.ts
@@ -275,7 +275,7 @@ describe('Tasks Page - Child View (?child=id)', () => {
     expect(html).toContain('name="groupId"')
   })
 
-  it('should highlight overdue tasks', async () => {
+  it('shows a past-due task but never marks it as overdue', async () => {
     const yesterday = new Date()
     yesterday.setDate(yesterday.getDate() - 1)
 
@@ -291,11 +291,11 @@ describe('Tasks Page - Child View (?child=id)', () => {
     const html = await renderChildPage()
 
     expect(html).toContain('Overdue Task')
-    expect(html).toContain('data-overdue="true"')
-    expect(html).toContain('Überfällig')
+    expect(html).not.toContain('data-overdue="true"')
+    expect(html).not.toContain('Überfällig')
   })
 
-  it('should sort overdue tasks before non-overdue tasks', async () => {
+  it('does not hoist past-due tasks above others (sorts purely by priority)', async () => {
     const yesterday = new Date()
     yesterday.setDate(yesterday.getDate() - 1)
     const today = new Date()
@@ -319,9 +319,10 @@ describe('Tasks Page - Child View (?child=id)', () => {
 
     const html = await renderChildPage()
 
+    // Higher priority (1) comes first; being past-due no longer jumps the queue.
     const overdueIndex = html.indexOf('Overdue Task')
     const todayIndex = html.indexOf('Today Task')
-    expect(overdueIndex).toBeLessThan(todayIndex)
+    expect(todayIndex).toBeLessThan(overdueIndex)
   })
 
   it('should order tasks by priority', async () => {

--- a/packages/frontend/tests/pages/group/time-travel.integration.test.ts
+++ b/packages/frontend/tests/pages/group/time-travel.integration.test.ts
@@ -331,10 +331,10 @@ describe('Time-Travel Integration Tests', () => {
     })
   })
 
-  // ====== D. Overdue Display ======
+  // ====== D. Past-due tasks are shown but never marked overdue ======
 
-  describe('D. Overdue Display', () => {
-    it('overdue task shows overdue badge', async () => {
+  describe('D. No overdue marking', () => {
+    it('past-due task still shows, without an overdue badge', async () => {
       travelTo('2026-03-10T13:00:00Z')
       await createTask({
         title: 'Alte Aufgabe',
@@ -342,11 +342,12 @@ describe('Time-Travel Integration Tests', () => {
         dueDate: '2026-03-08',
       })
       const html = await renderPage()
-      expect(html).toContain('data-overdue="true"')
-      expect(html).toContain('Überfällig')
+      expect(html).toContain('Alte Aufgabe')
+      expect(html).not.toContain('data-overdue="true"')
+      expect(html).not.toContain('data-testid="overdue-badge"')
     })
 
-    it('task due today does NOT show overdue badge', async () => {
+    it('task due today shows without an overdue badge', async () => {
       travelTo('2026-03-10T13:00:00Z')
       await createTask({
         title: 'Heute',
@@ -358,7 +359,7 @@ describe('Time-Travel Integration Tests', () => {
       expect(html).not.toContain('data-overdue="true"')
     })
 
-    it('task due yesterday shows overdue badge', async () => {
+    it('task due yesterday shows without an overdue badge', async () => {
       travelTo('2026-03-10T13:00:00Z')
       await createTask({
         title: 'Gestern',
@@ -366,10 +367,11 @@ describe('Time-Travel Integration Tests', () => {
         dueDate: '2026-03-09',
       })
       const html = await renderPage()
-      expect(html).toContain('data-overdue="true"')
+      expect(html).toContain('Gestern')
+      expect(html).not.toContain('data-overdue="true"')
     })
 
-    it('overdue tasks sorted before non-overdue', async () => {
+    it('past-due tasks are not hoisted above others (priority order only)', async () => {
       travelTo('2026-03-10T13:00:00Z')
       await createTask({
         title: 'NormaleAufgabe',
@@ -378,18 +380,19 @@ describe('Time-Travel Integration Tests', () => {
         priority: 1,
       })
       await createTask({
-        title: 'ÜberfälligeAufgabe',
+        title: 'AelterePrio2',
         timeOfDay: 'afternoon',
         dueDate: '2026-03-08',
         priority: 2,
       })
       const html = await renderPage()
-      const overduePos = html.indexOf('ÜberfälligeAufgabe')
+      const olderPos = html.indexOf('AelterePrio2')
       const normalPos = html.indexOf('NormaleAufgabe')
-      expect(overduePos).toBeLessThan(normalPos)
+      // Higher priority (1) first; the older due date no longer wins.
+      expect(normalPos).toBeLessThan(olderPos)
     })
 
-    it('multiple overdue tasks sorted by priority', async () => {
+    it('multiple past-due tasks sorted by priority', async () => {
       travelTo('2026-03-10T13:00:00Z')
       await createTask({
         title: 'Prio2',
@@ -409,22 +412,22 @@ describe('Time-Travel Integration Tests', () => {
       expect(prio1Pos).toBeLessThan(prio2Pos)
     })
 
-    it('task becomes overdue at midnight Berlin: badge shows at 00:01 next day', async () => {
+    it('task never gets an overdue badge, even after its due date passes', async () => {
       await createTask({
-        title: 'WirdÜberfällig',
+        title: 'TaeglicheAufgabe',
         timeOfDay: 'morning',
         dueDate: '2026-03-10',
       })
 
       travelTo('2026-03-10T06:00:00Z')
       const htmlBefore = await renderPage()
-      expect(htmlBefore).toContain('WirdÜberfällig')
+      expect(htmlBefore).toContain('TaeglicheAufgabe')
       expect(htmlBefore).not.toContain('data-overdue="true"')
 
       travelTo('2026-03-10T23:01:00Z')
       const htmlAfter = await renderPage()
-      expect(htmlAfter).toContain('WirdÜberfällig')
-      expect(htmlAfter).toContain('data-overdue="true"')
+      expect(htmlAfter).toContain('TaeglicheAufgabe')
+      expect(htmlAfter).not.toContain('data-overdue="true"')
     })
   })
 

--- a/packages/frontend/tests/pages/group/unified-view.integration.test.ts
+++ b/packages/frontend/tests/pages/group/unified-view.integration.test.ts
@@ -130,8 +130,6 @@ describe('Unified Task View', () => {
       expect(html).toContain('data-testid="complete-button"')
       // task points badge
       expect(html).toContain('data-testid="task-points"')
-      // overdue badge (task is from yesterday)
-      expect(html).toContain('data-testid="overdue-badge"')
     })
 
     it('detail task cards should have same structure', async () => {
@@ -150,12 +148,11 @@ describe('Unified Task View', () => {
       expect(html).toContain('data-task-title="Bonus Task"')
       expect(html).toContain('data-testid="complete-button"')
       expect(html).toContain('data-testid="task-points"')
-      expect(html).toContain('data-testid="overdue-badge"')
     })
   })
 
-  describe('Overview uses string comparison for overdue (not Date)', () => {
-    it('should mark yesterday task as overdue in overview using string comparison', async () => {
+  describe('Overview never marks past-due tasks as overdue', () => {
+    it('shows a yesterday task in the overview without any overdue marker', async () => {
       await adminPb.collection('tasks').create({
         title: 'Yesterday Task',
         child: child1Id,
@@ -167,8 +164,9 @@ describe('Unified Task View', () => {
 
       const html = await renderOverview()
 
-      expect(html).toContain('data-overdue="true"')
-      expect(html).toContain('data-testid="overdue-badge"')
+      expect(html).toContain('Yesterday Task')
+      expect(html).not.toContain('data-overdue="true"')
+      expect(html).not.toContain('data-testid="overdue-badge"')
     })
   })
 


### PR DESCRIPTION
The kids didn't like tasks being flagged as **überfällig**, so the overdue feature is removed completely.

## Behavior
- Past-due tasks are **still shown** so they can be completed.
- They are **no longer** highlighted (red badge/border), **no longer** carry a `data-overdue` marker, and the `overdue-badge` is gone.
- Sorting is now **purely by priority** — a past-due task is no longer hoisted to the top.
- `dailyOnly`/Tagesaufgaben behavior is unchanged (those still expire silently on their day).

## Changes
- `tasks/index.astro`: removed the `isOverdue` computation, `data-overdue` attribute, red styling, and the "Überfällig" badge.
- `lib/tasks.ts` `sortTasks`: dropped overdue-first sorting (priority only).
- Updated every test that asserted the old overdue behavior to assert past-due tasks render **without** any overdue marker, and added `no-overdue.integration.test.ts` as a focused regression test.

## Testing
- Full frontend suite green: **248 passed (35 files)**. Typecheck clean.

https://claude.ai/code/session_01B95eZ9ULprC63znPMTZ1Ki

---
_Generated by [Claude Code](https://claude.ai/code/session_01B95eZ9ULprC63znPMTZ1Ki)_