### PR TITLE
Smooth task-completion animations via Astro view transitions

### DIFF
--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -247,6 +247,8 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                     return (
                       <li
                         data-testid="task-item"
+                        transition:name={`task-${task.id}`}
+                        transition:animate="fade"
                         class:list={[
                           'flex items-center gap-4 p-4 rounded-xl min-h-[56px] transition-transform duration-150 active:scale-[0.97] hover:shadow-md cursor-pointer',
                           'bg-base-200',
@@ -308,6 +310,8 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                     {completed.map((task) => (
                       <li
                         data-testid="completed-task-item"
+                        transition:name={`task-${task.id}`}
+                        transition:animate="fade"
                         class="flex items-center gap-4 p-3 rounded-xl bg-base-200/50 opacity-60"
                       >
                         <div class="flex-1">
@@ -338,6 +342,8 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                     {futureTasks.map((task) => (
                       <li
                         data-testid="future-task-item"
+                        transition:name={`task-${task.id}`}
+                        transition:animate="fade"
                         class="flex items-center gap-4 p-3 rounded-xl bg-base-200/30 opacity-50"
                       >
                         <div class="flex-1">

--- a/packages/frontend/tests/pages/group/task-transitions.integration.test.ts
+++ b/packages/frontend/tests/pages/group/task-transitions.integration.test.ts
@@ -1,0 +1,142 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, it, beforeEach } from 'vitest'
+import PocketBase from 'pocketbase'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { resetPocketBase } from '@/lib/pocketbase'
+import { getCurrentPhase, getLocalDateString } from '@/lib/tasks'
+import { authUser } from '../../helpers'
+
+const POCKETBASE_URL = process.env.POCKETBASE_URL || 'http://pocketbase-test:8090'
+
+/**
+ * Regression tests for the per-task Astro view transitions.
+ *
+ * The smooth "check off a task and the list closes the gap" effect relies on
+ * every task element getting its OWN Astro view transition (`transition:name`),
+ * so the browser can morph each surviving task to its new slot and animate the
+ * completed one out — instead of the whole list hard-cutting.
+ *
+ * Astro compiles a `transition:*` directive into a per-element
+ * `data-astro-transition-scope` attribute. Note: Astro's Container API does NOT
+ * emit the generated <style> that maps the scope to the actual
+ * `view-transition-name`, so we can only assert here that each task PARTICIPATES
+ * in a transition and gets its OWN scope (one per task, never a single shared
+ * block). Verifying the concrete name value (`task-<id>`) requires a real
+ * browser and lives in the E2E layer.
+ */
+describe('Task list view transitions', () => {
+  let adminPb: PocketBase
+  let userPb: PocketBase
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+  let currentPhase: string
+  let todayStr: string
+
+  beforeEach(async () => {
+    resetPocketBase()
+    adminPb = new PocketBase(POCKETBASE_URL)
+    await adminPb.collection('_superusers').authWithPassword('admin@test.local', 'testtest123')
+
+    const email = `vt-${Date.now()}@test.local`
+    const user = await adminPb.collection('users').create({
+      email,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+    })
+
+    userPb = new PocketBase(POCKETBASE_URL)
+    await userPb.collection('users').authWithPassword(email, 'testtest123')
+
+    const group = await adminPb.collection('groups').create({
+      name: 'VT Family',
+      morningEnd: '00:00',
+      eveningStart: '23:59',
+    })
+    groupId = group.id
+    currentPhase = getCurrentPhase('00:00', '23:59', 'Europe/Berlin')
+    todayStr = getLocalDateString('Europe/Berlin')
+
+    await adminPb.collection('user_groups').create({ user: user.id, group: groupId })
+
+    const child = await adminPb.collection('children').create({
+      name: 'Mia',
+      color: '#FF6B6B',
+      group: groupId,
+    })
+    childId = child.id
+
+    container = await AstroContainer.create()
+  })
+
+  const render = (child?: string) =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      request: child
+        ? new Request(`http://localhost/group/${groupId}/tasks?child=${child}`)
+        : undefined,
+      locals: { pb: userPb, user: authUser(userPb) },
+    })
+
+  const scopesFor = (html: string, testid: string): string[] => {
+    const re = new RegExp(
+      `<li data-testid="${testid}"[^>]*?data-astro-transition-scope="([^"]*)"`,
+      'g',
+    )
+    return [...html.matchAll(re)].map((m) => m[1])
+  }
+
+  it('gives every active task its own Astro view transition scope', async () => {
+    for (const title of ['Zähne putzen', 'Aufräumen', 'Tisch decken']) {
+      await adminPb.collection('tasks').create({
+        title,
+        child: childId,
+        completed: false,
+        timeOfDay: currentPhase,
+        dueDate: todayStr,
+      })
+    }
+
+    const html = await render(childId)
+    const scopes = scopesFor(html, 'task-item')
+
+    // One transition per task...
+    expect(scopes).toHaveLength(3)
+    // ...and each task is named individually (no single shared block), which is
+    // what lets the surviving tasks morph/slide independently.
+    expect(new Set(scopes).size).toBe(3)
+  })
+
+  it('also gives completed ("Heute erledigt") tasks their own transition scope', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Schon erledigt',
+      child: childId,
+      completed: true,
+      completedAt: new Date().toISOString(),
+      timeOfDay: currentPhase,
+      dueDate: todayStr,
+    })
+
+    const html = await render(childId)
+
+    // So that completing a task morphs it from the active list into the done
+    // list (and undo morphs it back) instead of popping.
+    expect(scopesFor(html, 'completed-task-item')).toHaveLength(1)
+  })
+
+  it('does not regress to a static slide / no transition on task items', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Zähne putzen',
+      child: childId,
+      completed: false,
+      timeOfDay: currentPhase,
+      dueDate: todayStr,
+    })
+
+    const html = await render(childId)
+
+    expect(html).not.toContain('transition:animate="slide"')
+    // The directive must actually reach the rendered task item.
+    expect(html).toMatch(/<li data-testid="task-item"[^>]*data-astro-transition-scope=/)
+  })
+})

--- a/packages/frontend/tests/pages/view-transitions.integration.test.ts
+++ b/packages/frontend/tests/pages/view-transitions.integration.test.ts
@@ -83,5 +83,22 @@ describe('View Transitions', () => {
 
       expect(html).toMatch(/data-testid="child-column"[^>]*data-astro-transition-scope/)
     })
+
+    it('should give each task item its own transition scope so the list can morph', async () => {
+      await adminPb.collection('tasks').create({
+        title: 'Zähne putzen',
+        child: child1Id,
+        completed: false,
+        timeOfDay: 'afternoon',
+      })
+
+      const html = await container.renderToString(TasksPage, {
+        params: { groupId },
+        request: new Request(`http://localhost/group/${groupId}/tasks?child=${child1Id}`),
+        locals: { pb: userPb, user: authUser(userPb) },
+      })
+
+      expect(html).toMatch(/<li data-testid="task-item"[^>]*data-astro-transition-scope=/)
+    })
   })
 })


### PR DESCRIPTION
## Problem

Beim Abhaken einer Aufgabe ist die Liste gesprungen: die erledigte Zeile verschwand und alles darunter ruckte beim nächsten Render hart nach oben. Das fühlte sich wie ein harter Page-Reload an.

## Lösung

Rein **Astro View Transitions** – kein eigenes CSS, kein eigenes JavaScript, weiterhin volle Seiten-Navigation mit Astros eingebauten Übergängen (und deren Fallbacks).

Jedes Aufgaben-Element bekommt eine eigene, stabile View-Transition über `transition:name={`task-${id}`}`. Damit verfolgt der Browser jede Aufgabe über die Navigation hinweg:

- Die abgehakte Aufgabe behält ihren Namen in der „Heute erledigt“-Liste und **gleitet smooth nach unten** in den Erledigt-Bereich (bzw. faded aus, wenn sie ganz verschwindet, z. B. wiederkehrende/Tagesaufgaben).
- Die übrigen Aufgaben **rutschen sanft hoch** und schließen die Lücke, statt zu springen.

Aktive, erledigte und zukünftige Aufgaben sind alle benannt, sodass Abhaken **und** Rückgängig-Machen animiert sind.

## Diff

Die einzige Produktionsänderung: `transition:name` + `transition:animate="fade"` auf den drei Task-`<li>`-Typen in `tasks/index.astro`. `Layout.astro` (mit `<ViewTransitions/>`) und `app.css` bleiben unverändert.

## Tests

- `task-transitions.integration.test.ts`: jede Aufgabe bekommt ihre **eigene** Transition-Scope (eine pro Aufgabe, nie ein gemeinsamer Block) — genau die Regression, die das Per-Item-Morphing still kaputt machen würde.
- `view-transitions.integration.test.ts`: erweitert, prüft jetzt auch, dass Task-Items eine Transition-Scope tragen.

Voller Suite: **252 Tests grün** (248 vorher + 4 neu).

### Was sich sinnvoll testen lässt — und was nicht

Astros Container API rendert das per-Element `data-astro-transition-scope`, aber **nicht** das generierte `<style>` mit dem konkreten `view-transition-name`. Auf der Integrationsebene lässt sich daher belastbar testen, dass **jede Aufgabe an einer eigenen Transition teilnimmt** (fängt das versehentliche Entfernen der Direktive bzw. einen gemeinsamen statischen Namen ab). Den konkreten Namen (`task-<id>`) und das tatsächliche visuelle Morphing zu prüfen, bräuchte einen echten Browser (E2E) — sag Bescheid, wenn du das zusätzlich willst, dann ergänze ich einen Playwright-Test, der `getComputedStyle(li).viewTransitionName` pro Aufgabe verifiziert.

https://claude.ai/code/session_017hD7YcySgroURWxUH5Ztor

---
_Generated by [Claude Code](https://claude.ai/code/session_017hD7YcySgroURWxUH5Ztor)_