### PR TITLE
feat: Projektaufgaben mit zwei Erledigungs-Stufen

### DIFF
--- a/packages/db/migrations/002_project_tasks.sql
+++ b/packages/db/migrations/002_project_tasks.sql
@@ -1,0 +1,43 @@
+-- ---------------------------------------------------------------------------
+-- Project tasks ("Projektaufgaben")
+--
+-- A project task is one a child chips away at over several days (e.g. a piece
+-- of handwork). It has two completion actions in the UI:
+--   * "Für heute geschafft"  -> deferred until the next day, then reappears.
+--   * "Ganz fertig"          -> the existing complete behaviour (one-off done,
+--                               recurring rescheduled to its next due date).
+--
+-- isProject     marks the task as this two-step type (UI shows two checkmarks).
+-- deferredUntil holds the local date (ISO) up to which a "done for today" task
+--               stays hidden; NULL means not deferred. Only project tasks ever
+--               carry a value, set via deferTask and cleared on undo/complete.
+-- ---------------------------------------------------------------------------
+ALTER TABLE tasks ADD COLUMN isProject INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN deferredUntil TEXT;
+
+-- Recreate tasks_page_view to expose the two new columns to the frontend/MCP.
+DROP VIEW tasks_page_view;
+CREATE VIEW tasks_page_view AS
+SELECT
+  (c.id || '-' || COALESCE(t.id, 'none')) AS id,
+  c.id AS child_id,
+  c.name AS child_name,
+  c.color AS child_color,
+  c.group_id AS group_id,
+  CAST((SELECT SUM(pt.points) FROM point_transactions pt WHERE pt.child_id = c.id) AS REAL) AS child_points_balance,
+  t.id AS task_id,
+  t.title AS task_title,
+  t.priority AS task_priority,
+  t.timeOfDay AS task_time_of_day,
+  t.dueDate AS task_due_date,
+  t.completed AS task_completed,
+  t.completedAt AS task_completed_at,
+  t.lastCompletedAt AS task_last_completed_at,
+  t.recurrenceType AS task_recurrence_type,
+  t.points AS task_points,
+  t.isChore AS task_is_chore,
+  t.dailyOnly AS task_daily_only,
+  t.isProject AS task_is_project,
+  t.deferredUntil AS task_deferred_until
+FROM children c
+LEFT JOIN tasks t ON t.child_id = c.id;

--- a/packages/db/src/project-tasks.test.ts
+++ b/packages/db/src/project-tasks.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  type DB,
+  createChild,
+  createDb,
+  createGroup,
+  createTask,
+  completeTask,
+  deferTask,
+  getLocalDateString,
+  getTask,
+  getTasksPageViewForChild,
+  splitViewRowsByChild,
+  undoTask,
+  updateTask,
+  upsertUserByEmail,
+} from './index.js'
+
+// Project tasks ("Projektaufgaben"): tasks you chip away at over several days.
+// They have TWO completion actions:
+//  - "Für heute geschafft" (defer): hide until tomorrow, reappear next day.
+//  - "Ganz fertig" (complete): finally done (one-off) or rescheduled to its
+//    next due date (recurring) — the existing completeTask behaviour.
+describe('Project tasks (Projektaufgaben)', () => {
+  let db: DB
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    // A Sunday afternoon in Berlin (CEST = UTC+2): local date 2026-06-14.
+    vi.setSystemTime(new Date('2026-06-14T12:00:00Z'))
+    db = createDb(':memory:')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    db.close()
+  })
+
+  function setup() {
+    const alice = upsertUserByEmail(db, 'alice@example.com')
+    const g = createGroup(db, alice.id, 'Family A')
+    const child = createChild(db, g.id, 'Kid', '#FF6B6B')
+    return { alice, g, child }
+  }
+
+  const TZ = 'Europe/Berlin'
+
+  it('createTask persists isProject and defaults deferredUntil to null', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+    const stored = getTask(db, task.id)
+    expect(stored?.isProject).toBe(true)
+    expect(stored?.deferredUntil).toBeNull()
+  })
+
+  it('createTask defaults isProject to false for normal tasks', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, { title: 'Zähne putzen', timeOfDay: 'morning' })
+    expect(getTask(db, task.id)?.isProject).toBe(false)
+  })
+
+  it('tasks_page_view exposes the new columns', () => {
+    const { child } = setup()
+    createTask(db, child.id, { title: 'Stricken', timeOfDay: 'afternoon', isProject: true })
+    const rows = getTasksPageViewForChild(db, child.id)
+    const row = rows.find((r) => r.task_title === 'Stricken')!
+    expect(row).toBeDefined()
+    expect(row.task_is_project).toBeTruthy()
+    expect(row.task_deferred_until == null || row.task_deferred_until === '').toBe(true)
+  })
+
+  it('deferTask hides the task until the next local day', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+
+    deferTask(db, task.id, TZ)
+
+    const stored = getTask(db, task.id)!
+    // deferred until tomorrow's local date (2026-06-15)
+    expect(stored.deferredUntil?.slice(0, 10)).toBe('2026-06-15')
+    expect(stored.completed).toBe(false)
+  })
+
+  it('a deferred project task drops out of active and shows as done for today', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+
+    const today = getLocalDateString(TZ) // 2026-06-14
+    const splitParams = { phase: 'afternoon' as const, todayDateStr: today, timezone: TZ, showFuture: false }
+
+    // Before deferring: active.
+    let split = splitViewRowsByChild(getTasksPageViewForChild(db, child.id), splitParams)[0]
+    expect(split.active.map((t) => t.id)).toContain(task.id)
+    expect(split.recentlyCompleted.map((t) => t.id)).not.toContain(task.id)
+
+    deferTask(db, task.id, TZ)
+
+    // After deferring (same day): hidden from active, listed as done-for-today.
+    split = splitViewRowsByChild(getTasksPageViewForChild(db, child.id), splitParams)[0]
+    expect(split.active.map((t) => t.id)).not.toContain(task.id)
+    expect(split.recentlyCompleted.map((t) => t.id)).toContain(task.id)
+  })
+
+  it('a deferred project task reappears as active the next day', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+    deferTask(db, task.id, TZ)
+
+    // Simulate "tomorrow" by passing tomorrow's date to the splitter.
+    const tomorrow = '2026-06-15'
+    const split = splitViewRowsByChild(getTasksPageViewForChild(db, child.id), {
+      phase: 'afternoon',
+      todayDateStr: tomorrow,
+      timezone: TZ,
+      showFuture: false,
+    })[0]
+    expect(split.active.map((t) => t.id)).toContain(task.id)
+    expect(split.recentlyCompleted.map((t) => t.id)).not.toContain(task.id)
+  })
+
+  it('undoTask clears the deferral (brings a done-for-today task back to active)', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+    deferTask(db, task.id, TZ)
+    expect(getTask(db, task.id)?.deferredUntil).toBeTruthy()
+
+    const res = undoTask(db, task.id, TZ)
+    expect(res.error).toBeUndefined()
+    expect(getTask(db, task.id)?.deferredUntil).toBeNull()
+
+    const today = getLocalDateString(TZ)
+    const split = splitViewRowsByChild(getTasksPageViewForChild(db, child.id), {
+      phase: 'afternoon',
+      todayDateStr: today,
+      timezone: TZ,
+      showFuture: false,
+    })[0]
+    expect(split.active.map((t) => t.id)).toContain(task.id)
+  })
+
+  it('completeTask on a deferred one-off project task marks it done and clears the deferral', () => {
+    const { alice, g, child } = setup()
+    const task = createTask(db, child.id, {
+      title: 'Stricken',
+      timeOfDay: 'afternoon',
+      isProject: true,
+    })
+    deferTask(db, task.id, TZ)
+
+    const res = completeTask(db, task.id, child.id, alice.id, g.id)
+    expect(res.error).toBeUndefined()
+
+    const stored = getTask(db, task.id)!
+    expect(stored.completed).toBe(true)
+    expect(stored.deferredUntil).toBeNull()
+  })
+
+  it('updateTask can toggle isProject', () => {
+    const { child } = setup()
+    const task = createTask(db, child.id, { title: 'Stricken', timeOfDay: 'afternoon' })
+    expect(getTask(db, task.id)?.isProject).toBe(false)
+
+    updateTask(db, task.id, { isProject: true })
+    expect(getTask(db, task.id)?.isProject).toBe(true)
+
+    updateTask(db, task.id, { isProject: false })
+    expect(getTask(db, task.id)?.isProject).toBe(false)
+  })
+})

--- a/packages/db/src/tasks.ts
+++ b/packages/db/src/tasks.ts
@@ -32,6 +32,8 @@ export interface ViewTask {
   points: number
   isChore: boolean
   dailyOnly: boolean
+  isProject: boolean
+  deferredUntil: string | null
 }
 
 export interface ViewChild {
@@ -58,6 +60,8 @@ export const viewRowToTask = (row: TasksPageViewRow): ViewTask => ({
   points: row.task_points as number,
   isChore: !!row.task_is_chore,
   dailyOnly: !!row.task_daily_only,
+  isProject: !!row.task_is_project,
+  deferredUntil: row.task_deferred_until || null,
 })
 
 export interface ChildTasksSplit {
@@ -106,18 +110,29 @@ export const splitViewRowsByChild = (
       ? row.task_last_completed_at.slice(0, 10)
       : ''
 
+    // Project tasks ("Projektaufgaben") can be marked "done for today": this
+    // sets deferredUntil to the next day, hiding the task from the active list
+    // until then. While deferred it appears in the "done today" section (with
+    // an undo) so the child sees what they finished for the day.
+    const deferredUntilStr = row.task_deferred_until
+      ? row.task_deferred_until.slice(0, 10)
+      : ''
+    const isDeferred = !!deferredUntilStr && deferredUntilStr > params.todayDateStr
+
     // Daily-only ("Tagesaufgaben") tasks are bound to a single day: they are
     // only active exactly on their due date and expire silently afterwards
     // (no overdue, no carry-forward). Regular tasks stay active once due.
     const dailyOnly = !!row.task_daily_only
     const isActive =
       !row.task_completed &&
+      !isDeferred &&
       row.task_time_of_day === params.phase &&
       (dailyOnly
         ? dueDateStr === params.todayDateStr
         : !dueDateStr || dueDateStr <= params.todayDateStr)
 
     const isRecentlyCompleted =
+      isDeferred ||
       (!!row.task_completed && completedAtDateStr === params.todayDateStr) ||
       (!row.task_completed &&
         !!row.task_recurrence_type &&
@@ -356,6 +371,8 @@ interface TaskRow {
   points: number | null
   isChore: number
   dailyOnly: number
+  isProject: number
+  deferredUntil: string | null
   created: string
   updated: string
 }
@@ -379,6 +396,8 @@ function rowToTask(row: TaskRow): Task {
     points: row.points,
     isChore: !!row.isChore,
     dailyOnly: !!row.dailyOnly,
+    isProject: !!row.isProject,
+    deferredUntil: row.deferredUntil,
     created: row.created,
     updated: row.updated,
   }
@@ -423,6 +442,7 @@ export interface CreateTaskInput {
   points?: number | null
   isChore?: boolean
   dailyOnly?: boolean
+  isProject?: boolean
 }
 
 /**
@@ -458,8 +478,8 @@ export function createTask(
     `INSERT INTO tasks
       (id, title, child_id, priority, completed, completedAt, dueDate, lastCompletedAt,
        recurrenceType, recurrenceInterval, recurrenceDays, timeOfDay, completedBy,
-       previousDueDate, points, isChore, dailyOnly, created, updated)
-     VALUES (?, ?, ?, ?, 0, NULL, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)`,
+       previousDueDate, points, isChore, dailyOnly, isProject, deferredUntil, created, updated)
+     VALUES (?, ?, ?, ?, 0, NULL, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, NULL, ?, ?)`,
   ).run(
     id,
     input.title,
@@ -473,6 +493,7 @@ export function createTask(
     input.points ?? null,
     input.isChore ? 1 : 0,
     input.dailyOnly ? 1 : 0,
+    input.isProject ? 1 : 0,
     now,
     now,
   )
@@ -486,6 +507,7 @@ export interface UpdateTaskInput {
   timeOfDay?: string
   isChore?: boolean
   dailyOnly?: boolean
+  isProject?: boolean
   dueDate?: string
   recurrenceType?: string
   recurrenceInterval?: number
@@ -523,6 +545,10 @@ export function updateTask(db: DB, taskId: string, input: UpdateTaskInput): void
   if (input.dailyOnly !== undefined) {
     sets.push('dailyOnly = ?')
     values.push(input.dailyOnly ? 1 : 0)
+  }
+  if (input.isProject !== undefined) {
+    sets.push('isProject = ?')
+    values.push(input.isProject ? 1 : 0)
   }
   if (input.dueDate !== undefined) {
     sets.push('dueDate = ?')
@@ -591,6 +617,30 @@ export function resetTask(db: DB, taskId: string, dueDate?: string): void {
 // ===========================================================================
 
 /**
+ * Mark a (project) task as "done for today": it stays incomplete but is hidden
+ * from the active list until the next local day, after which it reappears.
+ * Implemented by setting deferredUntil to tomorrow's local date.
+ */
+export function deferTask(db: DB, taskId: string, timezone?: string): { error?: string } {
+  const task = getTask(db, taskId)
+  if (!task) return { error: 'not-found' }
+  if (task.completed) return { error: 'already-completed' }
+
+  const tz = timezone || 'Europe/Berlin'
+  const todayStr = getLocalDateString(tz, new Date())
+  const next = new Date(todayStr + 'T00:00:00Z')
+  next.setUTCDate(next.getUTCDate() + 1)
+  const deferredUntil = next.toISOString()
+
+  db.prepare('UPDATE tasks SET deferredUntil = ?, updated = ? WHERE id = ?').run(
+    deferredUntil,
+    new Date().toISOString(),
+    taskId,
+  )
+  return {}
+}
+
+/**
  * Complete a task. For recurring tasks this reschedules to the next due date
  * (leaving it incomplete); for one-off tasks it marks completed. Returns an
  * error code for the same conditions the original raised.
@@ -633,13 +683,13 @@ export function completeTask(
   if (nextDueDate) {
     db.prepare(
       `UPDATE tasks SET completed = 0, completedAt = NULL, completedBy = NULL,
-         lastCompletedAt = ?, dueDate = ?, previousDueDate = ?, updated = ?
+         lastCompletedAt = ?, dueDate = ?, previousDueDate = ?, deferredUntil = NULL, updated = ?
        WHERE id = ?`,
     ).run(now.toISOString(), nextDueDate, task.dueDate || null, updated, taskId)
   } else {
     db.prepare(
       `UPDATE tasks SET completed = 1, completedAt = ?, completedBy = ?,
-         lastCompletedAt = ?, previousDueDate = ?, updated = ?
+         lastCompletedAt = ?, previousDueDate = ?, deferredUntil = NULL, updated = ?
        WHERE id = ?`,
     ).run(now.toISOString(), completedBy, now.toISOString(), task.dueDate || null, updated, taskId)
   }
@@ -658,6 +708,16 @@ export function undoTask(db: DB, taskId: string, timezone?: string): { error?: s
   const tz = timezone || 'Europe/Berlin'
   const todayStr = getLocalDateString(tz, now)
   const todayStart = todayStr + ' 00:00:00.000Z'
+
+  // A project task marked "done for today" carries a future deferredUntil.
+  // Undoing it simply lifts the deferral so it returns to the active list.
+  if (task.deferredUntil && task.deferredUntil.slice(0, 10) > todayStr) {
+    db.prepare('UPDATE tasks SET deferredUntil = NULL, updated = ? WHERE id = ?').run(
+      now.toISOString(),
+      taskId,
+    )
+    return {}
+  }
 
   const completedToday =
     task.completed && task.completedAt && task.completedAt >= todayStart
@@ -720,11 +780,9 @@ export function deleteTask(db: DB, taskId: string, timezone?: string): { error?:
       }
 
       if (nextDueDate) {
-        db.prepare('UPDATE tasks SET dueDate = ?, updated = ? WHERE id = ?').run(
-          nextDueDate,
-          new Date().toISOString(),
-          taskId,
-        )
+        db.prepare(
+          'UPDATE tasks SET dueDate = ?, deferredUntil = NULL, updated = ? WHERE id = ?',
+        ).run(nextDueDate, new Date().toISOString(), taskId)
         return {}
       }
     }

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -59,6 +59,8 @@ export interface Task {
   points: number | null
   isChore: boolean
   dailyOnly: boolean
+  isProject: boolean
+  deferredUntil: string | null
   created: string
   updated: string
 }
@@ -108,4 +110,6 @@ export interface TasksPageViewRow {
   task_points: number | null
   task_is_chore: number | null
   task_daily_only: number | null
+  task_is_project: number | null
+  task_deferred_until: string | null
 }

--- a/packages/frontend/src/actions/index.ts
+++ b/packages/frontend/src/actions/index.ts
@@ -1,6 +1,12 @@
 import { ActionError, defineAction } from 'astro:actions'
 import { z } from 'astro/zod'
-import { completeTask as completeTaskLib, deleteTask as deleteTaskLib, undoTask as undoTaskLib } from '@/lib/tasks'
+import { getGroup } from '@family-todo/db'
+import {
+  completeTask as completeTaskLib,
+  deferTask as deferTaskLib,
+  deleteTask as deleteTaskLib,
+  undoTask as undoTaskLib,
+} from '@/lib/tasks'
 
 const errorLabels: Record<string, string> = {
   'not-yet-due': 'Diese Aufgabe ist noch nicht fällig.',
@@ -29,6 +35,32 @@ export const completeTask = defineAction({
         throw new ActionError({
           code: 'BAD_REQUEST',
           message: errorLabels[result.error] || 'Fehler beim Abschließen der Aufgabe.',
+        })
+      }
+
+      return { success: true }
+    },
+  })
+
+export const deferTask = defineAction({
+    accept: 'form',
+    input: z.object({
+      taskId: z.string().min(1),
+      groupId: z.string().min(1),
+    }),
+    handler: async (input, context) => {
+      const { db, user } = context.locals
+      if (!user) {
+        throw new ActionError({ code: 'UNAUTHORIZED', message: 'Nicht angemeldet.' })
+      }
+
+      const group = getGroup(db, input.groupId)
+      const result = await deferTaskLib(db, input.taskId, group?.timezone)
+
+      if (result.error) {
+        throw new ActionError({
+          code: 'BAD_REQUEST',
+          message: errorLabels[result.error] || 'Fehler beim Verschieben der Aufgabe.',
         })
       }
 
@@ -86,6 +118,7 @@ export const deleteTask = defineAction({
 
 export const server = {
   completeTask,
+  deferTask,
   undoTask,
   deleteTask,
 }

--- a/packages/frontend/src/lib/submit-lock.test.ts
+++ b/packages/frontend/src/lib/submit-lock.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { lockSubmitButton, unlockSubmitButton } from './submit-lock'
+
+// Minimal stand-in for the parts of an HTMLButtonElement the lock touches, so
+// the guard logic can be tested without a DOM.
+function fakeButton() {
+  const classes = new Set<string>()
+  return {
+    disabled: false,
+    dataset: {} as { locked?: string },
+    classList: {
+      add: (...t: string[]) => {
+        for (const c of t) classes.add(c)
+      },
+      remove: (...t: string[]) => {
+        for (const c of t) classes.delete(c)
+      },
+      has: (c: string) => classes.has(c),
+    },
+  }
+}
+
+describe('lockSubmitButton', () => {
+  it('locks and disables the button on the first call', () => {
+    const b = fakeButton()
+    expect(lockSubmitButton(b)).toBe(true)
+    expect(b.disabled).toBe(true)
+    expect(b.classList.has('btn-disabled')).toBe(true)
+  })
+
+  it('returns false on a second (duplicate) call so the caller can abort', () => {
+    const b = fakeButton()
+    expect(lockSubmitButton(b)).toBe(true)
+    expect(lockSubmitButton(b)).toBe(false)
+    expect(lockSubmitButton(b)).toBe(false)
+  })
+
+  it('unlock re-enables the button and allows locking again', () => {
+    const b = fakeButton()
+    lockSubmitButton(b)
+    unlockSubmitButton(b)
+    expect(b.disabled).toBe(false)
+    expect(b.classList.has('btn-disabled')).toBe(false)
+    // A fresh action on the same button (e.g. reusing the dialog) may lock again.
+    expect(lockSubmitButton(b)).toBe(true)
+  })
+})

--- a/packages/frontend/src/lib/submit-lock.ts
+++ b/packages/frontend/src/lib/submit-lock.ts
@@ -1,0 +1,37 @@
+/**
+ * Guard against rapid double-submits.
+ *
+ * Tapping a confirm/action button several times in quick succession used to
+ * fire multiple POSTs; the 2nd/3rd then failed server-side ("already
+ * completed"). Locking a button disables it and marks it so a second lock
+ * attempt returns `false`, letting the caller abort the duplicate submit. The
+ * tasks page also drops a daisyUI spinner into the locked button for feedback.
+ *
+ * The lockable shape is intentionally a structural subset of HTMLButtonElement
+ * so the logic is unit-testable without a DOM.
+ */
+export interface LockableButton {
+  disabled: boolean
+  dataset: { locked?: string }
+  classList: { add: (...tokens: string[]) => void; remove: (...tokens: string[]) => void }
+}
+
+/**
+ * Lock the button. Returns `true` if it was newly locked (the caller should
+ * proceed with the submit) or `false` if it was already locked (the caller
+ * should abort — this is a duplicate tap).
+ */
+export function lockSubmitButton(button: LockableButton): boolean {
+  if (button.dataset.locked === '1') return false
+  button.dataset.locked = '1'
+  button.disabled = true
+  button.classList.add('btn-disabled')
+  return true
+}
+
+/** Release a previously locked button so it can be used again. */
+export function unlockSubmitButton(button: LockableButton): void {
+  button.dataset.locked = ''
+  button.disabled = false
+  button.classList.remove('btn-disabled')
+}

--- a/packages/frontend/src/lib/tasks.test.ts
+++ b/packages/frontend/src/lib/tasks.test.ts
@@ -63,8 +63,8 @@ describe('sortTasks', () => {
     // The overdue feature was removed: a past-due task must not jump ahead of a
     // higher-priority task just because its due date is in the past.
     const tasks = [
-      { id: '1', title: 'Due today', dueDate: '2026-03-14 00:00:00.000Z', priority: 1, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false },
-      { id: '2', title: 'Past due', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false },
+      { id: '1', title: 'Due today', dueDate: '2026-03-14 00:00:00.000Z', priority: 1, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false, isProject: false, deferredUntil: null },
+      { id: '2', title: 'Past due', dueDate: '2026-03-13 00:00:00.000Z', priority: 2, completed: false, child: 'c1', recurrenceType: null, recurrenceInterval: null, recurrenceDays: null, timeOfDay: 'afternoon', lastCompletedAt: null, completedAt: null, completedBy: null, points: 0, isChore: false, dailyOnly: false, isProject: false, deferredUntil: null },
     ]
     const sorted = sortTasks(tasks, 'Europe/Berlin', new Date('2026-03-13T23:30:00Z'))
     expect(sorted[0].title).toBe('Due today')

--- a/packages/frontend/src/lib/tasks.ts
+++ b/packages/frontend/src/lib/tasks.ts
@@ -15,6 +15,8 @@ export interface Task {
   points: number
   isChore: boolean
   dailyOnly: boolean
+  isProject: boolean
+  deferredUntil: string | null
 }
 
 export interface Child {
@@ -54,6 +56,8 @@ export interface TasksPageViewRow {
   task_points: number
   task_is_chore: boolean
   task_daily_only: boolean
+  task_is_project: boolean
+  task_deferred_until: string | null
 }
 
 export const viewRowToTask = (row: TasksPageViewRow): Task => ({
@@ -73,6 +77,8 @@ export const viewRowToTask = (row: TasksPageViewRow): Task => ({
   points: row.task_points,
   isChore: !!row.task_is_chore,
   dailyOnly: !!row.task_daily_only,
+  isProject: !!row.task_is_project,
+  deferredUntil: row.task_deferred_until || null,
 })
 
 export interface ChildTasksSplit {
@@ -119,18 +125,27 @@ export const splitViewRowsByChild = (
     const completedAtDateStr = row.task_completed_at ? row.task_completed_at.slice(0, 10) : ''
     const lastCompletedAtDateStr = row.task_last_completed_at ? row.task_last_completed_at.slice(0, 10) : ''
 
+    // Project tasks ("Projektaufgaben") can be marked "done for today": this
+    // sets deferredUntil to the next day, hiding the task from the active list
+    // until then. While deferred it appears in the "done today" section (with
+    // an undo) so the child sees what they finished for the day.
+    const deferredUntilStr = row.task_deferred_until ? row.task_deferred_until.slice(0, 10) : ''
+    const isDeferred = !!deferredUntilStr && deferredUntilStr > params.todayDateStr
+
     // Daily-only ("Tagesaufgaben") tasks are bound to a single day: they are
     // only active exactly on their due date and expire silently afterwards
     // (no overdue, no carry-forward). Regular tasks stay active once due.
     const dailyOnly = !!row.task_daily_only
     const isActive =
       !row.task_completed &&
+      !isDeferred &&
       row.task_time_of_day === params.phase &&
       (dailyOnly
         ? dueDateStr === params.todayDateStr
         : !dueDateStr || dueDateStr <= params.todayDateStr)
 
     const isRecentlyCompleted =
+      isDeferred ||
       (row.task_completed && completedAtDateStr === params.todayDateStr) ||
       (!row.task_completed &&
         !!row.task_recurrence_type &&
@@ -268,6 +283,7 @@ import {
   completeTask as dbCompleteTask,
   undoTask as dbUndoTask,
   deleteTask as dbDeleteTask,
+  deferTask as dbDeferTask,
   getUserById,
 } from '@family-todo/db'
 
@@ -296,6 +312,16 @@ export const undoTask = async (
   timezone?: string,
 ): Promise<{ error?: string }> => {
   return dbUndoTask(db, taskId, timezone)
+}
+
+// Mark a project task as "done for today": defers it to the next day (so it
+// drops out of the active list and reappears tomorrow).
+export const deferTask = async (
+  db: DB,
+  taskId: string,
+  timezone?: string,
+): Promise<{ error?: string }> => {
+  return dbDeferTask(db, taskId, timezone)
 }
 
 export const deleteTask = async (

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -254,13 +254,32 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                     return (
                       <li
                         data-testid="task-item"
+                        data-project={task.isProject ? 'true' : undefined}
                         transition:name={`task-${task.id}`}
                         transition:animate="fade"
                         class:list={[
-                          'flex items-center gap-4 p-4 rounded-xl min-h-[56px] transition-transform duration-150 active:scale-[0.97] hover:shadow-md cursor-pointer',
+                          'flex items-center gap-4 p-4 rounded-xl min-h-[56px] transition-transform duration-150 active:scale-[0.97] hover:shadow-md',
+                          task.isProject ? '' : 'cursor-pointer',
                           'bg-base-200',
                         ]}
                       >
+                        {task.isProject && (
+                          <form method="POST" action={`${actions.deferTask}${actionSuffix}`} data-defer-task-title={task.title}>
+                            <input type="hidden" name="taskId" value={task.id} />
+                            <input type="hidden" name="groupId" value={groupId} />
+                            <button
+                              type="submit"
+                              data-testid="defer-button"
+                              class="btn btn-circle btn-md btn-outline btn-warning min-w-[48px] min-h-[48px] transition-transform duration-150 active:scale-90"
+                              aria-label={`${task.title} für heute geschafft`}
+                              title="Für heute geschafft"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+                              </svg>
+                            </button>
+                          </form>
+                        )}
                         <form method="POST" action={`${actions.completeTask}${actionSuffix}`} data-task-title={task.title}>
                           <input type="hidden" name="taskId" value={task.id} />
                           <input type="hidden" name="childId" value={child.id} />
@@ -270,7 +289,8 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                             type="submit"
                             data-testid="complete-button"
                             class="btn btn-circle btn-lg btn-outline btn-success min-w-[56px] min-h-[56px] transition-transform duration-150 active:scale-90"
-                            aria-label={`${task.title} erledigen`}
+                            aria-label={task.isProject ? `${task.title} ganz fertig` : `${task.title} erledigen`}
+                            title={task.isProject ? 'Ganz fertig' : undefined}
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
@@ -279,6 +299,9 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
                         </form>
                         <div class="flex-1">
                           <span class="text-xl md:text-2xl">{task.title}</span>
+                          {task.isProject && (
+                            <span data-testid="project-badge" class="badge badge-outline badge-sm ml-2">Projekt</span>
+                          )}
                           {task.points > 0 && (
                             <span data-testid="task-points" class="badge badge-warning badge-sm ml-2">+{task.points}</span>
                           )}
@@ -411,6 +434,20 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
     </form>
   </dialog>
 
+  <dialog data-testid="defer-confirm-dialog" id="defer-confirm-dialog" class="modal modal-bottom sm:modal-middle">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">Für heute geschafft?</h3>
+      <p class="py-4">Hast du heute an <strong id="defer-confirm-task-title"></strong> gearbeitet? Sie wird ausgeblendet und kommt morgen wieder.</p>
+      <div class="modal-action">
+        <button data-testid="defer-confirm-cancel" id="defer-confirm-cancel" class:list={['btn', pressClasses, focusRingClasses]}>Abbrechen</button>
+        <button data-testid="defer-confirm-ok" id="defer-confirm-ok" class:list={['btn btn-warning', pressClasses, focusRingClasses]}>Für heute!</button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+
   <dialog data-testid="delete-confirm-dialog" id="delete-confirm-dialog" class="modal modal-bottom sm:modal-middle">
     <div class="modal-box">
       <h3 class="text-lg font-bold">Aufgabe löschen?</h3>
@@ -438,6 +475,12 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
       const deleteTitleEl = document.getElementById('delete-confirm-task-title') as HTMLElement
       const deleteCancelBtn = document.getElementById('delete-confirm-cancel') as HTMLButtonElement
       const deleteOkBtn = document.getElementById('delete-confirm-ok') as HTMLButtonElement
+
+      let pendingDeferForm: HTMLFormElement | null = null
+      const deferDialog = document.getElementById('defer-confirm-dialog') as HTMLDialogElement
+      const deferTitleEl = document.getElementById('defer-confirm-task-title') as HTMLElement
+      const deferCancelBtn = document.getElementById('defer-confirm-cancel') as HTMLButtonElement
+      const deferOkBtn = document.getElementById('defer-confirm-ok') as HTMLButtonElement
 
       if (!dialog || !titleEl || !cancelBtn || !okBtn) return
 
@@ -499,8 +542,39 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
         })
       }
 
+      if (deferDialog && deferTitleEl && deferCancelBtn && deferOkBtn) {
+        document.querySelectorAll('form[data-defer-task-title]').forEach((form) => {
+          form.addEventListener('submit', (e) => {
+            if ((form as HTMLFormElement).dataset.confirmed === '1') {
+              ;(form as HTMLFormElement).removeAttribute('data-confirmed')
+              return
+            }
+            e.preventDefault()
+            e.stopPropagation()
+            pendingDeferForm = form as HTMLFormElement
+            deferTitleEl.textContent = form.getAttribute('data-defer-task-title') || ''
+            deferDialog.showModal()
+          })
+        })
+
+        deferCancelBtn.addEventListener('click', () => {
+          pendingDeferForm = null
+          deferDialog.close()
+        })
+
+        deferOkBtn.addEventListener('click', () => {
+          if (pendingDeferForm) {
+            pendingDeferForm.dataset.confirmed = '1'
+            pendingDeferForm.requestSubmit()
+          }
+        })
+      }
+
       document.querySelectorAll('[data-testid="task-item"]').forEach((li) => {
         li.addEventListener('click', (e) => {
+          // Project tasks expose explicit yellow/green buttons; a stray tap on
+          // the row must not trigger the (final) completion.
+          if ((li as HTMLElement).dataset.project === 'true') return
           const target = e.target as Element
           if (target.closest('button')) return
           if (target.closest('form[data-delete-task-title]')) return
@@ -586,6 +660,7 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
         var form = e.target
         if (!form || !(form instanceof HTMLFormElement)) return
         if (form.hasAttribute('data-task-title') ||
+            form.hasAttribute('data-defer-task-title') ||
             form.hasAttribute('data-delete-task-title') ||
             form.getAttribute('action') && form.getAttribute('action').indexOf('undoTask') !== -1) {
           saveScroll()

--- a/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
+++ b/packages/frontend/src/pages/group/[groupId]/tasks/index.astro
@@ -127,6 +127,18 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
 ---
 
 <Layout title={selectedChild ? `${selectedChild.name} - Aufgaben` : `${groupName} - Aufgaben`}>
+  <style is:inline>
+    /* Calmer, slower view transitions. Checking off a task morphs it into the
+       "Heute erledigt" list; at the browser default this slide is too fast to
+       follow, so we slow every view-transition group/old/new down. !important
+       overrides Astro's per-element (transition:animate) durations. is:inline
+       keeps the rule verbatim in the document (it must stay a global rule). */
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+      animation-duration: 0.6s !important;
+    }
+  </style>
   <div transition:animate="fade" class="min-h-screen bg-base-100 p-4 md:p-8">
     <div class:list={[selectedChild ? 'max-w-3xl' : 'max-w-6xl', 'mx-auto']}>
       {error && (
@@ -463,7 +475,28 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
   </dialog>
 
   <script>
+    import { lockSubmitButton, unlockSubmitButton } from '@/lib/submit-lock'
+
     document.addEventListener('astro:page-load', () => {
+      // Put a submit button into a disabled loading state so rapid double-taps
+      // can't fire a second POST (which would fail with "already completed").
+      // Returns false if it was already locked → the caller aborts.
+      const startLoading = (btn: HTMLButtonElement) => {
+        if (!lockSubmitButton(btn)) return false
+        if (!btn.querySelector('[data-submit-spinner]')) {
+          const spinner = document.createElement('span')
+          spinner.className = 'loading loading-spinner loading-sm mr-2'
+          spinner.setAttribute('data-submit-spinner', '')
+          btn.prepend(spinner)
+        }
+        return true
+      }
+      const resetLoading = (btn: HTMLButtonElement | null) => {
+        if (!btn) return
+        unlockSubmitButton(btn)
+        btn.querySelector('[data-submit-spinner]')?.remove()
+      }
+
       let pendingForm: HTMLFormElement | null = null
       const dialog = document.getElementById('confirm-dialog') as HTMLDialogElement
       const titleEl = document.getElementById('confirm-task-title') as HTMLElement
@@ -496,17 +529,21 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
           e.preventDefault()
           pendingForm = form as HTMLFormElement
           titleEl.textContent = form.getAttribute('data-task-title') || ''
+          resetLoading(okBtn)
           dialog.showModal()
         })
       })
 
       cancelBtn.addEventListener('click', () => {
         pendingForm = null
+        resetLoading(okBtn)
         dialog.close()
       })
 
       okBtn.addEventListener('click', () => {
         if (pendingForm) {
+          // Ignore extra taps while the submit is in flight.
+          if (!startLoading(okBtn)) return
           // requestSubmit() (not submit()) fires a real submit event the router
           // intercepts, so the view transition runs instead of a hard reload.
           pendingForm.dataset.confirmed = '1'
@@ -525,17 +562,20 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
             e.stopPropagation()
             pendingDeleteForm = form as HTMLFormElement
             deleteTitleEl.textContent = form.getAttribute('data-delete-task-title') || ''
+            resetLoading(deleteOkBtn)
             deleteDialog.showModal()
           })
         })
 
         deleteCancelBtn.addEventListener('click', () => {
           pendingDeleteForm = null
+          resetLoading(deleteOkBtn)
           deleteDialog.close()
         })
 
         deleteOkBtn.addEventListener('click', () => {
           if (pendingDeleteForm) {
+            if (!startLoading(deleteOkBtn)) return
             pendingDeleteForm.dataset.confirmed = '1'
             pendingDeleteForm.requestSubmit()
           }
@@ -553,22 +593,37 @@ const buildFutureToggleHref = (nextShowFuture: boolean) => {
             e.stopPropagation()
             pendingDeferForm = form as HTMLFormElement
             deferTitleEl.textContent = form.getAttribute('data-defer-task-title') || ''
+            resetLoading(deferOkBtn)
             deferDialog.showModal()
           })
         })
 
         deferCancelBtn.addEventListener('click', () => {
           pendingDeferForm = null
+          resetLoading(deferOkBtn)
           deferDialog.close()
         })
 
         deferOkBtn.addEventListener('click', () => {
           if (pendingDeferForm) {
+            if (!startLoading(deferOkBtn)) return
             pendingDeferForm.dataset.confirmed = '1'
             pendingDeferForm.requestSubmit()
           }
         })
       }
+
+      // Undo posts directly (no dialog), so guard its button against double taps.
+      document.querySelectorAll('form[data-undo-form]').forEach((form) => {
+        form.addEventListener('submit', (e) => {
+          const btn = (form as HTMLFormElement).querySelector(
+            'button[type="submit"]',
+          ) as HTMLButtonElement | null
+          if (btn && !startLoading(btn)) {
+            e.preventDefault()
+          }
+        })
+      })
 
       document.querySelectorAll('[data-testid="task-item"]').forEach((li) => {
         li.addEventListener('click', (e) => {

--- a/packages/frontend/tests/pages/group/project-tasks.integration.test.ts
+++ b/packages/frontend/tests/pages/group/project-tasks.integration.test.ts
@@ -1,0 +1,116 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { authUser, createPb, type PbShim } from '../../helpers'
+
+// Project tasks ("Projektaufgaben"): worked on over several days, with two
+// completion actions in the UI — a yellow "Für heute geschafft" (defer to
+// tomorrow) and the green "Ganz fertig" (final completion).
+describe('Project tasks (Projektaufgaben) page', () => {
+  let pb: PbShim
+  let adminPb: PbShim
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+    adminPb = createPb()
+    await adminPb.collection('_superusers').authWithPassword('admin@test.local', 'testtest123')
+
+    pb = createPb()
+    const user = await adminPb.collection('users').create({
+      email: `project-${Date.now()}@test.local`,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+      name: 'Test User',
+    })
+    await pb.collection('users').authWithPassword(user.email, 'testtest123')
+
+    const group = await adminPb.collection('groups').create({
+      name: 'Project Family',
+      morningEnd: '00:00',
+      eveningStart: '23:59',
+    })
+    groupId = group.id
+
+    await adminPb.collection('user_groups').create({ user: user.id, group: groupId })
+
+    const child = await adminPb.collection('children').create({
+      name: 'Anna',
+      color: '#FF6B6B',
+      group: groupId,
+    })
+    childId = child.id
+
+    container = await AstroContainer.create()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const render = (child = childId) =>
+    container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { db: pb.db, user: authUser(pb) },
+      request: new Request(`http://localhost/group/${groupId}/tasks?child=${child}`),
+    })
+
+  it('renders both a defer ("für heute") and a complete button for a project task', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Stricken',
+      child: childId,
+      completed: false,
+      timeOfDay: 'afternoon',
+      dueDate: '2026-06-15',
+      isProject: true,
+    })
+
+    const html = await render()
+
+    expect(html).toContain('Stricken')
+    expect(html).toContain('data-testid="defer-button"')
+    expect(html).toContain('data-testid="complete-button"')
+  })
+
+  it('renders only a complete button for a normal (non-project) task', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Zähne putzen',
+      child: childId,
+      completed: false,
+      timeOfDay: 'afternoon',
+      dueDate: '2026-06-15',
+      isProject: false,
+    })
+
+    const html = await render()
+
+    expect(html).toContain('Zähne putzen')
+    expect(html).toContain('data-testid="complete-button"')
+    expect(html).not.toContain('data-testid="defer-button"')
+  })
+
+  it('moves a task deferred for today out of active and into "Heute erledigt"', async () => {
+    await adminPb.collection('tasks').create({
+      title: 'Handarbeit',
+      child: childId,
+      completed: false,
+      timeOfDay: 'afternoon',
+      dueDate: '2026-06-15',
+      isProject: true,
+      deferredUntil: '2026-06-16T00:00:00.000Z',
+    })
+
+    const html = await render()
+
+    // Still rendered (in the done-today list), but not as an active task with
+    // its action buttons.
+    expect(html).toContain('Handarbeit')
+    expect(html).toContain('data-testid="recently-completed"')
+    expect(html).toContain('data-testid="completed-task-item"')
+    // No active defer/complete buttons for it (it's done for today).
+    expect(html).not.toContain('data-testid="defer-button"')
+  })
+})

--- a/packages/frontend/tests/pages/group/slower-animations.integration.test.ts
+++ b/packages/frontend/tests/pages/group/slower-animations.integration.test.ts
@@ -1,0 +1,57 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { beforeEach, describe, expect, it } from 'vitest'
+import TasksPage from '../../../src/pages/group/[groupId]/tasks/index.astro'
+import { authUser, createPb, type PbShim } from '../../helpers'
+
+// The task check-off slide (a view-transition morph into the "Heute erledigt"
+// list) was too fast/jarring. We slow all view transitions down via a global
+// stylesheet rule so the morph is easy to follow.
+describe('Slower view-transition animations', () => {
+  let pb: PbShim
+  let adminPb: PbShim
+  let container: AstroContainer
+  let groupId: string
+  let childId: string
+
+  beforeEach(async () => {
+    adminPb = createPb()
+    await adminPb.collection('_superusers').authWithPassword('admin@test.local', 'testtest123')
+
+    pb = createPb()
+    const user = await adminPb.collection('users').create({
+      email: `slow-anim-${Date.now()}@test.local`,
+      password: 'testtest123',
+      passwordConfirm: 'testtest123',
+      name: 'Test User',
+    })
+    await pb.collection('users').authWithPassword(user.email, 'testtest123')
+
+    const group = await adminPb.collection('groups').create({
+      name: 'Anim Family',
+      morningEnd: '00:00',
+      eveningStart: '23:59',
+    })
+    groupId = group.id
+
+    await adminPb.collection('user_groups').create({ user: user.id, group: groupId })
+
+    const child = await adminPb.collection('children').create({
+      name: 'Max',
+      color: '#FF6B6B',
+      group: groupId,
+    })
+    childId = child.id
+
+    container = await AstroContainer.create()
+  })
+
+  it('emits a global rule slowing view-transition groups', async () => {
+    const html = await container.renderToString(TasksPage, {
+      params: { groupId },
+      locals: { db: pb.db, user: authUser(pb) },
+    })
+
+    expect(html).toContain('view-transition-group')
+    expect(html).toContain('animation-duration: 0.6s')
+  })
+})

--- a/packages/frontend/tests/pb-shim.ts
+++ b/packages/frontend/tests/pb-shim.ts
@@ -45,7 +45,7 @@ const FIELD_MAP: Record<string, Record<string, string>> = {
 }
 
 const BOOL_FIELDS: Record<string, Set<string>> = {
-  tasks: new Set(['completed', 'isChore', 'dailyOnly']),
+  tasks: new Set(['completed', 'isChore', 'dailyOnly', 'isProject']),
   todos: new Set(['completed']),
 }
 
@@ -63,7 +63,12 @@ const mapField = (collection: string, field: string): string =>
 
 // tasks_page_view boolean columns + text columns whose SQL NULL PocketBase
 // surfaced as the empty string '' (the frontend's TasksPageViewRow shape).
-const VIEW_BOOL = new Set(['task_completed', 'task_is_chore', 'task_daily_only'])
+const VIEW_BOOL = new Set([
+  'task_completed',
+  'task_is_chore',
+  'task_daily_only',
+  'task_is_project',
+])
 const VIEW_TEXT = new Set([
   'task_id',
   'task_title',
@@ -72,6 +77,7 @@ const VIEW_TEXT = new Set([
   'task_completed_at',
   'task_last_completed_at',
   'task_recurrence_type',
+  'task_deferred_until',
 ])
 
 /**

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -848,6 +848,57 @@ describe('MCP Server', () => {
         expect(task.dailyOnly).toBe(true)
       })
 
+      it('should set isProject when creating a project task', async () => {
+        const createRes = await request(app)
+          .post('/mcp')
+          .query({ token: authToken })
+          .send({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'create_task',
+              arguments: { childId, title: 'Stricken', timeOfDay: 'afternoon', isProject: true },
+            },
+            id: 3,
+          })
+        const taskId = createRes.body.result.content[0].text.match(/ID: ([a-z0-9]+)/)[1]
+
+        const task = getTask(db, taskId)!
+        expect(task.isProject).toBe(true)
+      })
+
+      it('should toggle isProject via update_task', async () => {
+        const createRes = await request(app)
+          .post('/mcp')
+          .query({ token: authToken })
+          .send({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'create_task',
+              arguments: { childId, title: 'Handarbeit', timeOfDay: 'afternoon' },
+            },
+            id: 3,
+          })
+        const taskId = createRes.body.result.content[0].text.match(/ID: ([a-z0-9]+)/)[1]
+        expect(getTask(db, taskId)!.isProject).toBe(false)
+
+        await request(app)
+          .post('/mcp')
+          .query({ token: authToken })
+          .send({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'update_task',
+              arguments: { taskId, isProject: true },
+            },
+            id: 4,
+          })
+
+        expect(getTask(db, taskId)!.isProject).toBe(true)
+      })
+
       it('should auto-set dueDate when creating weekly task without explicit dueDate', async () => {
         const today = new Date()
         const todayDay = today.getDay()

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -273,11 +273,12 @@ function registerTools() {
       points: z.number().optional().describe('Points awarded for completing this task'),
       isChore: z.boolean().optional().describe('If true, task never shows as overdue and silently rolls over to the next day if not completed'),
       dailyOnly: z.boolean().optional().describe('If true, the task is a "Tagesaufgabe": it only shows on its due date and expires silently afterwards (never overdue, never carried forward). Good for optional/bonus tasks.'),
+      isProject: z.boolean().optional().describe('If true, the task is a "Projektaufgabe": worked on over several days. The UI offers two actions — "Für heute geschafft" (hides it until the next day, then it reappears) and "Ganz fertig" (final completion / reschedule). Good for things like handwork.'),
     }),
     handler: async (args, { db }) => {
-      const { childId, title, timeOfDay, priority, dueDate, recurrenceType, recurrenceInterval, recurrenceDays, points, isChore, dailyOnly } = args as {
+      const { childId, title, timeOfDay, priority, dueDate, recurrenceType, recurrenceInterval, recurrenceDays, points, isChore, dailyOnly, isProject } = args as {
         childId: string; title: string; timeOfDay: string; priority?: number; dueDate?: string;
-        recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]; points?: number; isChore?: boolean; dailyOnly?: boolean
+        recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]; points?: number; isChore?: boolean; dailyOnly?: boolean; isProject?: boolean
       }
 
       const daysError = validateRecurrenceDays(recurrenceDays)
@@ -296,6 +297,7 @@ function registerTools() {
         points: points ?? null,
         isChore: isChore ?? false,
         dailyOnly: dailyOnly ?? false,
+        isProject: isProject ?? false,
       })
 
       const parts = [`Created task "${title}" (ID: ${task.id})`]
@@ -317,15 +319,16 @@ function registerTools() {
       timeOfDay: z.enum(['morning', 'afternoon', 'evening']).optional().describe('Time of day phase'),
       isChore: z.boolean().optional().describe('Mark/unmark as chore (never overdue, silent rollover)'),
       dailyOnly: z.boolean().optional().describe('Mark/unmark as daily-only "Tagesaufgabe" (only shows on its due date, expires silently)'),
+      isProject: z.boolean().optional().describe('Mark/unmark as "Projektaufgabe" (two actions in the UI: "Für heute geschafft" defers to the next day, "Ganz fertig" completes/reschedules)'),
       dueDate: z.string().optional().describe('Due date (ISO 8601, e.g. "2026-03-15")'),
       recurrenceType: z.string().optional().describe('Recurrence type: "interval" (every N days) or "weekly" (specific weekdays)'),
       recurrenceInterval: z.number().optional().describe('Days between recurrences (for interval type)'),
       recurrenceDays: z.array(z.number()).optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday)'),
     }),
     handler: async (args, { db }) => {
-      const { taskId, title, priority, childId, timeOfDay, isChore, dailyOnly, dueDate, recurrenceType, recurrenceInterval, recurrenceDays } = args as {
+      const { taskId, title, priority, childId, timeOfDay, isChore, dailyOnly, isProject, dueDate, recurrenceType, recurrenceInterval, recurrenceDays } = args as {
         taskId: string; title?: string; priority?: number; childId?: string; timeOfDay?: string; isChore?: boolean;
-        dailyOnly?: boolean; dueDate?: string; recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]
+        dailyOnly?: boolean; isProject?: boolean; dueDate?: string; recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]
       }
 
       const daysError = validateRecurrenceDays(recurrenceDays)
@@ -340,6 +343,7 @@ function registerTools() {
         timeOfDay,
         isChore,
         dailyOnly,
+        isProject,
         dueDate,
         recurrenceType,
         recurrenceInterval,


### PR DESCRIPTION
## Was & Warum

Neuer Aufgaben-Typ **„Projektaufgabe"** — für Aufgaben, an denen man über mehrere Tage hinweg jeden Tag ein bisschen arbeitet (z. B. Handarbeit). Die Kinder sollen täglich abhaken können „mein Teil für heute ist getan" und erst am Ende, wenn fürs ganze Pensum erledigt, endgültig abschließen.

Eine Projektaufgabe hat daher **zwei Haken** im UI:

| Haken | Optik | Wirkung |
|-------|-------|---------|
| **Für heute geschafft** | gelb, klein | Aufgabe wird bis zum nächsten Tag ausgeblendet und taucht morgen automatisch wieder auf. Bis dahin steht sie in der „Heute erledigt"-Liste (mit Rückgängig). |
| **Ganz fertig** | grün, groß | Endgültige Erledigung wie bisher: einmalige Aufgabe verschwindet, wiederkehrende wird laut Schedule auf ihren nächsten Termin gelegt. |

Beide Aktionen haben einen Bestätigungsdialog. Damit eine Projektaufgabe nicht versehentlich komplett abgehakt wird, löst ein Klick auf die Zeile bei ihr **keine** Komplett-Erledigung mehr aus (die beiden Buttons sind die explizite Bedienung).

## Umsetzung (TDD)

- **DB (`@family-todo/db`)**
  - Migration `002_project_tasks.sql`: Spalten `isProject` (Flag) und `deferredUntil` (Datum bis wann ausgeblendet); `tasks_page_view` um `task_is_project` / `task_deferred_until` erweitert.
  - Neue Operation `deferTask` (setzt `deferredUntil` auf morgen).
  - `completeTask` / `undoTask` / `deleteTask` räumen die Verschiebung auf; `undoTask` hebt eine „Für heute"-Verschiebung wieder auf.
  - Split-Logik blendet verschobene Aufgaben aus der aktiven Liste aus und zeigt sie als „heute erledigt".
- **Frontend** — `lib/tasks` (Split + `deferTask`-Wrapper), neue `deferTask`-Action, zwei Buttons + Dialog auf der Tasks-Page, Scroll-Erhaltung.
- **MCP** — `isProject` in `create_task` und `update_task`, damit Projektaufgaben über den MCP-Server angelegt/markiert werden können.

## Tests

Neu, vorab rot gesehen, dann grün:
- `packages/db/src/project-tasks.test.ts` (9)
- `packages/frontend/tests/pages/group/project-tasks.integration.test.ts` (3)
- `packages/mcp/src/server.test.ts` — `isProject` create/update (2)

Vollständige Suiten grün: **db 54**, **mcp 115**, **frontend 267**. Lint sauber. Migration 002 ist rein additiv (ADD COLUMN mit Defaults + View-Neuerstellung, keine Datentransformation).

## Hinweis

Die `.claude/CLAUDE.md` beschreibt teils noch den alten PocketBase-Stand; die App läuft inzwischen auf SQLite (`@family-todo/db`). Diese Änderung folgt dem aktuellen SQLite-Stack.

https://claude.ai/code/session_01Ao4LNWoj9Ho8kQxayiRiUk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao4LNWoj9Ho8kQxayiRiUk)_