### PR TITLE
fix(mcp): accept null for nullable task fields in update_task/create_task

### DIFF
--- a/packages/db/src/tasks.ts
+++ b/packages/db/src/tasks.ts
@@ -502,16 +502,16 @@ export function createTask(
 
 export interface UpdateTaskInput {
   title?: string
-  priority?: number
+  priority?: number | null
   childId?: string
   timeOfDay?: string
   isChore?: boolean
   dailyOnly?: boolean
   isProject?: boolean
-  dueDate?: string
-  recurrenceType?: string
-  recurrenceInterval?: number
-  recurrenceDays?: number[]
+  dueDate?: string | null
+  recurrenceType?: string | null
+  recurrenceInterval?: number | null
+  recurrenceDays?: number[] | null
 }
 
 /**
@@ -564,7 +564,8 @@ export function updateTask(db: DB, taskId: string, input: UpdateTaskInput): void
   }
   if (input.recurrenceDays !== undefined) {
     sets.push('recurrenceDays = ?')
-    values.push(JSON.stringify(input.recurrenceDays))
+    // Store SQL NULL (not the literal string "null") when clearing the field.
+    values.push(input.recurrenceDays === null ? null : JSON.stringify(input.recurrenceDays))
   }
   if (sets.length === 0) return
   sets.push('updated = ?')

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -816,6 +816,67 @@ describe('MCP Server', () => {
         expect(res.body.result?.isError || res.body.error).toBeTruthy()
       })
 
+      it('should clear recurrence and priority via update_task with null', async () => {
+        // Mirrors a real "Handarbeit" task: a daily-after-completion interval
+        // task whose recurrence the parent wants to remove/fix. The natural way
+        // to express "remove this" is to send null, which previously failed the
+        // zod schema (fields were .optional() but not .nullable()) and surfaced
+        // to the user as a server-side "Invalid parameters" error.
+        const createRes = await request(app)
+          .post('/mcp')
+          .query({ token: authToken })
+          .send({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'create_task',
+              arguments: {
+                childId,
+                title: 'Handarbeit',
+                timeOfDay: 'afternoon',
+                priority: 1,
+                recurrenceType: 'interval',
+                recurrenceInterval: 1,
+              },
+            },
+            id: 3,
+          })
+        const taskId = createRes.body.result.content[0].text.match(/ID: ([a-z0-9]+)/)[1]
+
+        const res = await request(app)
+          .post('/mcp')
+          .query({ token: authToken })
+          .send({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'update_task',
+              arguments: {
+                taskId,
+                isProject: true,
+                priority: null,
+                recurrenceType: null,
+                recurrenceInterval: null,
+                recurrenceDays: null,
+                dueDate: null,
+              },
+            },
+            id: 4,
+          })
+
+        expect(res.status).toBe(200)
+        expect(res.body.error).toBeUndefined()
+        expect(res.body.result?.isError).toBeFalsy()
+
+        const task = getTask(db, taskId)!
+        expect(task.isProject).toBe(true)
+        expect(task.priority).toBeNull()
+        expect(task.recurrenceType).toBeNull()
+        expect(task.recurrenceInterval).toBeNull()
+        expect(task.recurrenceDays).toBeNull()
+        expect(task.dueDate).toBeNull()
+      })
+
       it('should set dailyOnly via update_task (#79)', async () => {
         const createRes = await request(app)
           .post('/mcp')

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -265,20 +265,20 @@ function registerTools() {
       childId: z.string().describe('ID of the child'),
       title: z.string().describe('Task title'),
       timeOfDay: z.enum(['morning', 'afternoon', 'evening']).describe('Time of day phase'),
-      priority: z.number().optional().describe('Priority (lower number = higher priority, null = lowest)'),
-      dueDate: z.string().optional().describe('Due date (ISO 8601, e.g. "2026-03-15")'),
-      recurrenceType: z.string().optional().describe('Recurrence type: "interval" (every N days) or "weekly" (specific weekdays)'),
-      recurrenceInterval: z.number().optional().describe('Days between recurrences (for interval type)'),
-      recurrenceDays: z.array(z.number()).optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday)'),
-      points: z.number().optional().describe('Points awarded for completing this task'),
+      priority: z.number().nullable().optional().describe('Priority (lower number = higher priority, null = lowest)'),
+      dueDate: z.string().nullable().optional().describe('Due date (ISO 8601, e.g. "2026-03-15")'),
+      recurrenceType: z.string().nullable().optional().describe('Recurrence type: "interval" (every N days) or "weekly" (specific weekdays)'),
+      recurrenceInterval: z.number().nullable().optional().describe('Days between recurrences (for interval type)'),
+      recurrenceDays: z.array(z.number()).nullable().optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday)'),
+      points: z.number().nullable().optional().describe('Points awarded for completing this task'),
       isChore: z.boolean().optional().describe('If true, task never shows as overdue and silently rolls over to the next day if not completed'),
       dailyOnly: z.boolean().optional().describe('If true, the task is a "Tagesaufgabe": it only shows on its due date and expires silently afterwards (never overdue, never carried forward). Good for optional/bonus tasks.'),
       isProject: z.boolean().optional().describe('If true, the task is a "Projektaufgabe": worked on over several days. The UI offers two actions — "Für heute geschafft" (hides it until the next day, then it reappears) and "Ganz fertig" (final completion / reschedule). Good for things like handwork.'),
     }),
     handler: async (args, { db }) => {
       const { childId, title, timeOfDay, priority, dueDate, recurrenceType, recurrenceInterval, recurrenceDays, points, isChore, dailyOnly, isProject } = args as {
-        childId: string; title: string; timeOfDay: string; priority?: number; dueDate?: string;
-        recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]; points?: number; isChore?: boolean; dailyOnly?: boolean; isProject?: boolean
+        childId: string; title: string; timeOfDay: string; priority?: number | null; dueDate?: string | null;
+        recurrenceType?: string | null; recurrenceInterval?: number | null; recurrenceDays?: number[] | null; points?: number | null; isChore?: boolean; dailyOnly?: boolean; isProject?: boolean
       }
 
       const daysError = validateRecurrenceDays(recurrenceDays)
@@ -314,21 +314,21 @@ function registerTools() {
     inputSchema: z.object({
       taskId: z.string().describe('ID of the task'),
       title: z.string().optional().describe('New title'),
-      priority: z.number().optional().describe('New priority'),
+      priority: z.number().nullable().optional().describe('New priority (null = lowest / no priority)'),
       childId: z.string().optional().describe('Reassign to different child'),
       timeOfDay: z.enum(['morning', 'afternoon', 'evening']).optional().describe('Time of day phase'),
       isChore: z.boolean().optional().describe('Mark/unmark as chore (never overdue, silent rollover)'),
       dailyOnly: z.boolean().optional().describe('Mark/unmark as daily-only "Tagesaufgabe" (only shows on its due date, expires silently)'),
       isProject: z.boolean().optional().describe('Mark/unmark as "Projektaufgabe" (two actions in the UI: "Für heute geschafft" defers to the next day, "Ganz fertig" completes/reschedules)'),
-      dueDate: z.string().optional().describe('Due date (ISO 8601, e.g. "2026-03-15")'),
-      recurrenceType: z.string().optional().describe('Recurrence type: "interval" (every N days) or "weekly" (specific weekdays)'),
-      recurrenceInterval: z.number().optional().describe('Days between recurrences (for interval type)'),
-      recurrenceDays: z.array(z.number()).optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday)'),
+      dueDate: z.string().nullable().optional().describe('Due date (ISO 8601, e.g. "2026-03-15"); null clears it'),
+      recurrenceType: z.string().nullable().optional().describe('Recurrence type: "interval" (every N days) or "weekly" (specific weekdays); null removes recurrence'),
+      recurrenceInterval: z.number().nullable().optional().describe('Days between recurrences (for interval type); null clears it'),
+      recurrenceDays: z.array(z.number()).nullable().optional().describe('Weekdays for recurrence (0=Sunday, 1=Monday, ..., 6=Saturday); null clears it'),
     }),
     handler: async (args, { db }) => {
       const { taskId, title, priority, childId, timeOfDay, isChore, dailyOnly, isProject, dueDate, recurrenceType, recurrenceInterval, recurrenceDays } = args as {
-        taskId: string; title?: string; priority?: number; childId?: string; timeOfDay?: string; isChore?: boolean;
-        dailyOnly?: boolean; isProject?: boolean; dueDate?: string; recurrenceType?: string; recurrenceInterval?: number; recurrenceDays?: number[]
+        taskId: string; title?: string; priority?: number | null; childId?: string; timeOfDay?: string; isChore?: boolean;
+        dailyOnly?: boolean; isProject?: boolean; dueDate?: string | null; recurrenceType?: string | null; recurrenceInterval?: number | null; recurrenceDays?: number[] | null
       }
 
       const daysError = validateRecurrenceDays(recurrenceDays)


### PR DESCRIPTION
## The bug

The MCP tool `update_task` failed **server-side** when a parent (driving the MCP server from Claude) tried to *clear* a nullable task field — for example fixing a wrong recurrence by removing it. Auth and all read tools worked fine; only updates that passed `null` failed.

Concretely, calling `update_task` with any of:

```jsonc
{ "taskId": "…", "recurrenceType": null }      // remove recurrence
{ "taskId": "…", "recurrenceInterval": null }  // clear the interval
{ "taskId": "…", "recurrenceDays": null }
{ "taskId": "…", "priority": null }            // "null = lowest", per the schema's own description
{ "taskId": "…", "dueDate": null }
```

returned JSON-RPC `-32602 Invalid parameters` (`Expected number, received null` / `Expected string, received null`), which surfaces to the user as a server error.

## Root cause

A schema vs. data-model mismatch in the MCP layer. The `tasks` columns are all nullable and the handlers already handle `null` correctly (`createTask` does `?? null`; `updateTask` writes whatever is passed and the `... !== undefined` guards intentionally allow `null` through to SQL). But the **zod input schemas** declared these fields as `.optional()` only — i.e. `T | undefined`, not `T | null` — so a `null` value failed `safeParse` in the `tools/call` dispatcher before the handler ever ran.

The happy-path updates the user also attempted (setting `isProject: true`, switching to weekly recurrence) were never broken — I confirmed this by replaying the real tool calls against a read-only snapshot of the production database. Only the `null` clears threw.

This is **not** a schema/migration problem: production already has all columns (`001`–`003` applied, `isProject`/`deferredUntil` present), and `quick_check` is `ok`.

## The fix

- Mark the nullable task fields `.nullable().optional()` in both the `create_task` and `update_task` zod input schemas (`packages/mcp/src/server.ts`).
- Widen the handler argument casts and the db `UpdateTaskInput` type to `T | null` (`packages/mcp/src/server.ts`, `packages/db/src/tasks.ts`).
- In `updateTask`, store SQL `NULL` rather than the literal string `"null"` when `recurrenceDays` is cleared.

## Reproduction / test

Added an integration test in `packages/mcp/src/server.test.ts` that creates a daily-after-completion interval task (mirroring the live "Handarbeit" task) and then, in a single `update_task` call, sets `isProject: true` and clears `priority`, `recurrenceType`, `recurrenceInterval`, `recurrenceDays`, and `dueDate` via `null`. The test fails on the old schema with `-32602` and passes with this fix.

`npm run test -w @family-todo/mcp` (116) and `-w @family-todo/db` (59) are green; `npm run build --workspaces` succeeds. The 4 failing frontend `time-travel.integration` tests are pre-existing and clock-dependent — they fail identically on a pristine checkout and are unrelated to this change.

## Manual production step

None required. No migration; production schema is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)