### PR TITLE
ci: fully-qualify production ref so first deploy creates the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,6 @@ jobs:
           git config user.email "deploy-bot@users.noreply.github.com"
           git add deploy/overlays/production/kustomization.yaml
           git commit -m "chore(deploy): roll to ${{ github.sha }}"
-          git push --force origin HEAD:production
+          # Fully-qualified ref so the first push creates 'production' (git won't
+          # guess a full refname for a branch that does not exist yet).
+          git push --force origin HEAD:refs/heads/production


### PR DESCRIPTION
Follow-up to #103. `git push --force origin HEAD:production` fails when `production` doesn't exist yet (git can't guess the full refname for a new branch), so the first deploy errored. Use `HEAD:refs/heads/production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)